### PR TITLE
Use queryConfig API for query in pgtyped-runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10252,9 +10252,9 @@
       }
     },
     "node_modules/rescript-embed-lang": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/rescript-embed-lang/-/rescript-embed-lang-0.5.1.tgz",
-      "integrity": "sha512-67X3lqYN3Ppbc56L1rtWoysv/BXp55VRUUVIrVneCh9AGlkHWce6zRs8B4PbOg60bGM5Wp0Z8Tek+djpONMX+A==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/rescript-embed-lang/-/rescript-embed-lang-0.5.2.tgz",
+      "integrity": "sha512-2ydfNj7M1qODaziHp1oWE2EmpB4d2pns0aDu3rup4d9oK4apnt+tt06DnUJKrduCpkq1eB7Ybj9JKUdFn4XJKg==",
       "hasInstallScript": true
     },
     "node_modules/resolve": {
@@ -12369,7 +12369,7 @@
         "pgtyped-rescript": "^2.4.0",
         "pgtyped-rescript-query": "^2.3.0",
         "rescript": "11.1.0",
-        "rescript-embed-lang": "^0.5.1",
+        "rescript-embed-lang": "^0.5.2",
         "typescript": "4.9.4"
       },
       "devDependencies": {
@@ -14024,7 +14024,7 @@
         "pgtyped-rescript": "^2.4.0",
         "pgtyped-rescript-query": "^2.3.0",
         "rescript": "11.1.0",
-        "rescript-embed-lang": "^0.5.1",
+        "rescript-embed-lang": "^0.5.2",
         "ts-node": "10.9.1",
         "typescript": "4.9.4"
       },
@@ -20210,9 +20210,9 @@
       "integrity": "sha512-9la2Dv+ACylQ77I8s4spPu1JnLZXbH5WgxcLHLLUBWgFFSiv0wXqgzWztrBIZqwFgVX5BYcwldUqUVcEzdCyHg=="
     },
     "rescript-embed-lang": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/rescript-embed-lang/-/rescript-embed-lang-0.5.1.tgz",
-      "integrity": "sha512-67X3lqYN3Ppbc56L1rtWoysv/BXp55VRUUVIrVneCh9AGlkHWce6zRs8B4PbOg60bGM5Wp0Z8Tek+djpONMX+A=="
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/rescript-embed-lang/-/rescript-embed-lang-0.5.2.tgz",
+      "integrity": "sha512-2ydfNj7M1qODaziHp1oWE2EmpB4d2pns0aDu3rup4d9oK4apnt+tt06DnUJKrduCpkq1eB7Ybj9JKUdFn4XJKg=="
     },
     "resolve": {
       "version": "1.22.1",

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -28,7 +28,7 @@
     "pgtyped-rescript": "^2.4.0",
     "pgtyped-rescript-query": "^2.3.0",
     "rescript": "11.1.0",
-    "rescript-embed-lang": "^0.5.1",
+    "rescript-embed-lang": "^0.5.2",
     "typescript": "4.9.4"
   },
   "devDependencies": {

--- a/packages/runtime/src/tag.ts
+++ b/packages/runtime/src/tag.ts
@@ -8,8 +8,8 @@ export interface ICursor<T> {
 }
 
 export interface IDatabaseConnection {
-  query: (query: string, bindings: any[]) => Promise<{ rows: any[] }>;
-  stream?: (query: string, bindings: any[]) => ICursor<any[]>;
+  query: (config: { text: string; values: any[] }) => Promise<{ rows: any[] }>;
+  stream?: (config: { text: string; values: any[] }) => ICursor<any[]>;
 }
 
 /** Check for column modifier suffixes (exclamation and question marks). */
@@ -55,7 +55,10 @@ export class TaggedQuery<TTypePair extends { params: any; result: any }> {
         this.query,
         params as any,
       );
-      const result = await connection.query(processedQuery, bindings);
+      const result = await connection.query({
+        text: processedQuery,
+        values: bindings,
+      });
       return mapQueryResultRows(result.rows);
     };
     this.stream = (params, connection) => {
@@ -65,7 +68,10 @@ export class TaggedQuery<TTypePair extends { params: any; result: any }> {
       );
       if (connection.stream == null)
         throw new Error("Connection doesn't support streaming.");
-      const cursor = connection.stream(processedQuery, bindings);
+      const cursor = connection.stream({
+        text: processedQuery,
+        values: bindings,
+      });
       return {
         async read(rowCount: number) {
           const rows = await cursor.read(rowCount);
@@ -112,7 +118,10 @@ export class PreparedQuery<TParamType, TResultType> {
         this.queryIR,
         params as any,
       );
-      const result = await connection.query(processedQuery, bindings);
+      const result = await connection.query({
+        text: processedQuery,
+        values: bindings,
+      });
       return mapQueryResultRows(result.rows);
     };
     this.stream = (params, connection) => {
@@ -122,7 +131,10 @@ export class PreparedQuery<TParamType, TResultType> {
       );
       if (connection.stream == null)
         throw new Error("Connection doesn't support streaming.");
-      const cursor = connection.stream(processedQuery, bindings);
+      const cursor = connection.stream({
+        text: processedQuery,
+        values: bindings,
+      });
       return {
         async read(rowCount: number) {
           const rows = await cursor.read(rowCount);


### PR DESCRIPTION
This allows the use of pgtyped with pg implementations that only support the [queryConfig API](https://node-postgres.com/apis/client#queryconfig), like in Grafast for example.

I'm not aware of any pg implementations that don't support queryConfig, so it should not have any impact on existing users.