### PR TITLE
Infer input types from json_populate_recordset and friends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # main
 
+- Make sure `JSON.t` is properly stringified so JSON arrays can be passed to params expecting `JSON.t` without them being confused for regular Postgres arrays.
 - Auto-escape all ReScript keywords in generated record field names.
 - Add automatic parsing of PostgreSQL check constraints to generate ReScript polyvariant types for enumeration-style constraints. Supports both `column IN (value1, value2, ...)` and `column = ANY (ARRAY[value1, value2, ...])` patterns with string and integer values.
 - Add top-level literal inference for SELECT queries. When a query returns literal values with aliases (e.g., `SELECT 'success' as status, 42 as code`), PgTyped now automatically infers specific polyvariant types like `[#"success"]` and `[#42]` instead of generic `string` and `int` types. This provides better type safety and autocompletion. Also works with UNION queries where literals are consistent across all branches.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Auto-escape all ReScript keywords in generated record field names.
 - Add automatic parsing of PostgreSQL check constraints to generate ReScript polyvariant types for enumeration-style constraints. Supports both `column IN (value1, value2, ...)` and `column = ANY (ARRAY[value1, value2, ...])` patterns with string and integer values.
 - Add top-level literal inference for SELECT queries. When a query returns literal values with aliases (e.g., `SELECT 'success' as status, 42 as code`), PgTyped now automatically infers specific polyvariant types like `[#"success"]` and `[#42]` instead of generic `string` and `int` types. This provides better type safety and autocompletion. Also works with UNION queries where literals are consistent across all branches.
+- Add support for PostgreSQL JSON population functions (`json_populate_record`, `json_populate_recordset`, `jsonb_populate_record`, `jsonb_populate_recordset`, `json_to_record`, `jsonb_to_recordset`). This supports efficient bulk operations.
 - Remove dependency on `@rescript/core` since it's not really used.
 
 # 2.6.0

--- a/RESCRIPT.md
+++ b/RESCRIPT.md
@@ -170,6 +170,75 @@ let books = await client->GetBooksByStatus.many({
 
 This feature works seamlessly with both separate SQL files and SQL-in-ReScript modes.
 
+## JSON Population Functions
+
+`pgtyped-rescript` provides support for PostgreSQL's JSON population functions, enabling type-safe conversion between JSON data and database records.
+
+### Supported Functions
+
+- **`json_populate_record`** - Converts a JSON object to a PostgreSQL record
+- **`json_populate_recordset`** - Converts a JSON array to a set of PostgreSQL records
+- **`jsonb_populate_record`** - Binary JSON variant of `json_populate_record`
+- **`jsonb_populate_recordset`** - Binary JSON variant of `json_populate_recordset`
+- **`json_to_record`** - Converts JSON to a record with explicit column definitions
+- **`jsonb_to_recordset`** - Converts JSONB array to records with explicit column definitions
+
+### Usage Examples
+
+**Bulk insert with `json_populate_recordset`:**
+
+```sql
+/* @name bulkInsertBooks */
+INSERT INTO books (name, author_id, categories, rank)
+SELECT
+  event.name,
+  event.author_id,
+  event.categories,
+  event.rank
+FROM json_populate_recordset(null::books, :books!) as event
+RETURNING *;
+```
+
+**Update single record with `json_populate_record`:**
+
+```sql
+/* @name updateBookFromJson */
+UPDATE books
+SET (name, author_id, categories, rank) = (
+  SELECT
+    r.name,
+    r.author_id,
+    r.categories,
+    r.rank
+  FROM json_populate_record(null::books, :bookData!) as r
+)
+WHERE id = :bookId!
+RETURNING *;
+```
+
+**Example:**
+
+```rescript
+let bulkInsert = %sql.many(`
+  INSERT INTO books (name, author_id, categories, rank)
+  SELECT
+    event.name,
+    event.author_id,
+    event.categories,
+    event.rank
+  FROM json_populate_recordset(null::books, :books!) as event
+  RETURNING *
+`)
+
+// Usage with full type safety
+let newBooks = await client->bulkInsert({
+  books: [
+    {name: "Book 1", author_id: 1, categories: ["fiction"], rank: 1},
+    {name: "Book 2", author_id: 2, categories: ["sci-fi"], rank: 2}
+  ]
+})
+```
+
 ## Literal Type Inference
 
 `pgtyped-rescript` automatically infers specific polyvariant types for literal values in your SQL queries, providing enhanced type safety and better development experience.

--- a/packages/cli/src/generator.ts
+++ b/packages/cli/src/generator.ts
@@ -355,7 +355,11 @@ export async function queryToTypeDeclarations(
 
       // Make sure any JSON.t or array of JSON is stringified, since Postgres otherwise might
       // treat it as a Postgres array.
-      if (tsTypeName === 'JSON.t' || tsTypeName === 'array<JSON.t>') {
+      if (
+        tsTypeName === 'JSON.t' ||
+        tsTypeName === 'array<JSON.t>' ||
+        tsTypeName === 'arrayJSON_t' // TODO(rescript) Should get rid of these intermediate types if possible.
+      ) {
         inputParamTransforms[param.assignedIndex.toString()] = {
           type: 'stringify',
         };

--- a/packages/cli/src/generator.ts
+++ b/packages/cli/src/generator.ts
@@ -11,6 +11,7 @@ import {
   SQLQueryAST,
   SQLQueryIR,
   TSQueryAST,
+  InputParamTransforms,
 } from '@pgtyped/parser';
 
 import { getTypes, TypeSource } from 'pgtyped-rescript-query';
@@ -20,7 +21,10 @@ import path from 'path';
 import { ParsedConfig } from './config.js';
 import { TypeAllocator, TypeMapping, TypeScope } from './types.js';
 import { parseCode as parseRescriptFile } from './parseRescript.js';
-import { IQueryTypes } from 'pgtyped-rescript-query/lib/actions';
+import {
+  IQueryTypes,
+  ConstraintValue,
+} from 'pgtyped-rescript-query/lib/actions';
 
 export enum ProcessingMode {
   SQL = 'sql-file',
@@ -34,16 +38,54 @@ export interface IField {
   comment?: string;
 }
 
-const interfaceGen = (interfaceName: string, contents: string) =>
-  `@gentype\ntype ${interfaceName} = {
-${contents}
-}\n\n`;
-
-export function escapeComment(comment: string) {
-  return comment.replace(/\*\//g, '*\\/');
+/**
+ * Generates a ReScript polyvariant type from check values
+ * e.g., [#"value1" | #"value2" | #42]
+ */
+function generatePolyvariant(checkValues: ConstraintValue[]): string {
+  return `[${checkValues
+    .map((v) => {
+      switch (v.type) {
+        case 'string':
+          return `#"${v.value}"`;
+        case 'integer':
+          return `#${v.value}`;
+      }
+    })
+    .join(' | ')}]`;
 }
 
-export const generateInterface = (interfaceName: string, fields: IField[]) => {
+/**
+ * Wraps a type in option<> if needed
+ */
+function wrapInOption(typeName: string, shouldWrap: boolean): string {
+  return shouldWrap ? `option<${typeName}>` : typeName;
+}
+
+/**
+ * Wraps a type in array<> if needed
+ */
+function wrapInArray(typeName: string, shouldWrap: boolean): string {
+  return shouldWrap ? `array<${typeName}>` : typeName;
+}
+
+/**
+ * Generates a ReScript record type from fields
+ */
+function generateRecordType(
+  fields: Array<{ name: string; type: string; required?: boolean }>,
+): string {
+  const fieldStrings = fields.map((field) => {
+    const optional = field.required === false ? '?' : '';
+    return `  ${getFieldName(field.name)}${optional}: ${field.type}`;
+  });
+  return `{\n${fieldStrings.join(',\n')}\n}`;
+}
+
+/**
+ * Generates a complete ReScript record interface with @gentype annotation
+ */
+function generateInterface(interfaceName: string, fields: IField[]): string {
   const sortedFields = fields
     .slice()
     .sort((a, b) => a.fieldName.localeCompare(b.fieldName));
@@ -54,11 +96,84 @@ export const generateInterface = (interfaceName: string, fields: IField[]) => {
         `  ${getFieldName(fieldName)}${optional ? '?' : ''}: ${fieldType},`,
     )
     .join('\n');
-  return interfaceGen(interfaceName, contents);
-};
+  return `@gentype\ntype ${interfaceName} = {\n${contents}\n}\n\n`;
+}
 
-export const generateTypeAlias = (typeName: string, alias: string) =>
-  `@gentype\ntype ${typeName} = ${alias}\n\n`;
+/**
+ * Generates a ReScript type alias with @gentype annotation
+ */
+function generateTypeAlias(typeName: string, alias: string): string {
+  return `@gentype\ntype ${typeName} = ${alias}\n\n`;
+}
+
+/**
+ * Processes a type with check values, returning either the original type or a polyvariant
+ */
+function processTypeWithCheckValues(
+  baseTypeName: string,
+  checkValues?: ConstraintValue[],
+): string {
+  if (checkValues != null && checkValues.length > 0) {
+    return generatePolyvariant(checkValues);
+  }
+  return baseTypeName;
+}
+
+/**
+ * Converts a name to ReScript naming convention (camelCase starting with lowercase)
+ */
+function toRescriptName(name: string): string {
+  if (name == null || name.length === 0) {
+    return name;
+  }
+  return `${name[0]?.toLowerCase() ?? ''}${name.slice(1)}`;
+}
+
+/**
+ * Handles ReScript reserved words by adding @as annotation
+ */
+function getFieldName(fieldName: string): string {
+  if (reservedReScriptWords.includes(fieldName)) {
+    return `@as("${fieldName}") ${fieldName}_`;
+  }
+  return fieldName;
+}
+
+/**
+ * Escapes comments for ReScript
+ */
+function escapeComment(comment: string): string {
+  return comment.replace(/\*\//g, '*\\/');
+}
+
+const reservedReScriptWords = [
+  'and',
+  'as',
+  'assert',
+  'await',
+  'constraint',
+  'else',
+  'exception',
+  'external',
+  'false',
+  'for',
+  'if',
+  'in',
+  'include',
+  'let',
+  'module',
+  'mutable',
+  'of',
+  'open',
+  'private',
+  'rec',
+  'switch',
+  'true',
+  'try',
+  'type',
+  'when',
+  'while',
+];
 
 type ParsedQuery =
   | {
@@ -75,7 +190,10 @@ export async function queryToTypeDeclarations(
   typeSource: TypeSource,
   types: TypeAllocator,
   config: ParsedConfig,
-): Promise<string> {
+): Promise<{
+  result: string;
+  inputParamTransforms: InputParamTransforms | null;
+}> {
   let queryData;
   let queryName;
   if (parsedQuery.mode === ProcessingMode.TS) {
@@ -83,12 +201,11 @@ export async function queryToTypeDeclarations(
     queryData = processTSQueryAST(parsedQuery.ast);
   } else {
     queryName = pascalCase(parsedQuery.ast.name);
-    queryData = processSQLQueryIR(queryASTToIR(parsedQuery.ast));
+    queryData = processSQLQueryIR(queryASTToIR(parsedQuery.ast, null));
   }
 
   const typeData = await typeSource(queryData);
   const interfaceName = toRescriptName(pascalCase(queryName));
-  const interfacePrefix = '';
 
   const typeError = 'errorCode' in typeData;
   const hasAnonymousColumns =
@@ -116,51 +233,69 @@ export async function queryToTypeDeclarations(
       explanation = `Query contains an anonymous column. Consider giving the column an explicit name.`;
     }
 
-    const returnInterface = generateTypeAlias(
-      `${interfacePrefix}${interfaceName}Result`,
-      'unit',
-    );
-    const paramInterface = generateTypeAlias(
-      `${interfacePrefix}${interfaceName}Params`,
-      'unit',
-    );
+    const returnInterface = generateTypeAlias(`${interfaceName}Result`, 'unit');
+    const paramInterface = generateTypeAlias(`${interfaceName}Params`, 'unit');
     const resultErrorComment = `/** Query '${queryName}' is invalid, so its result is assigned type 'unit'.\n * ${explanation} */\n`;
     const paramErrorComment = `/** Query '${queryName}' is invalid, so its parameters are assigned type 'unit'.\n * ${explanation} */\n`;
-    return `${resultErrorComment}${returnInterface}${paramErrorComment}${paramInterface}`;
+    return {
+      result: `${resultErrorComment}${returnInterface}${paramErrorComment}${paramInterface}`,
+      inputParamTransforms: null,
+    };
   }
 
-  const { returnTypes, paramMetadata } = typeData;
+  const { returnTypes, paramMetadata, inputTypes } = typeData;
 
   const returnFieldTypes: IField[] = [];
   const paramFieldTypes: IField[] = [];
   const records: string[] = [];
 
+  // Generate input type records
+  const inputTypeNames: Record<number, string> = {};
+  const inputParamTransforms: InputParamTransforms = {};
+  for (const [_, inputTypeInfo] of Object.entries(inputTypes || {})) {
+    const recordTypeName = `${interfaceName}_${inputTypeInfo.tableName}InputType`;
+    inputTypeNames[inputTypeInfo.assignedIndex] = recordTypeName;
+    if (inputTypeInfo.stringify) {
+      inputParamTransforms[inputTypeInfo.assignedIndex] = {
+        type: 'stringify',
+      };
+    }
+
+    const inputFieldTypes: IField[] = [];
+
+    for (const field of inputTypeInfo.fields) {
+      const baseTypeName = types.use(field.type, TypeScope.Parameter);
+      const tsTypeName = processTypeWithCheckValues(
+        baseTypeName,
+        field.checkValues,
+      );
+
+      inputFieldTypes.push({
+        fieldName: config.camelCaseColumnNames
+          ? camelCase(field.columnName)
+          : field.columnName,
+        fieldType: tsTypeName,
+        optional: field.optional,
+        comment: field.comment,
+      });
+    }
+
+    const inputRecord = generateInterface(recordTypeName, inputFieldTypes);
+    records.push(inputRecord);
+  }
+
   returnTypes.forEach(
     ({ returnName, type, nullable, comment, checkValues }) => {
-      let tsTypeName = types.use(type, TypeScope.Return);
-
-      if (checkValues != null && checkValues.length > 0) {
-        tsTypeName = `[${checkValues
-          .map((v) => {
-            switch (v.type) {
-              case 'string':
-                return `#"${v.value}"`;
-              case 'integer':
-                return `#${v.value}`;
-            }
-          })
-          .join(' | ')}]`;
-      }
+      const baseTypeName = types.use(type, TypeScope.Return);
+      let tsTypeName = processTypeWithCheckValues(baseTypeName, checkValues);
 
       const lastCharacter = returnName[returnName.length - 1]; // Checking for type hints
       const addNullability = lastCharacter === '?';
       const removeNullability = lastCharacter === '!';
-      if (
-        (addNullability || nullable || nullable == null) &&
-        !removeNullability
-      ) {
-        tsTypeName = 'option<' + tsTypeName + '>';
-      }
+      const shouldWrapInOption =
+        (addNullability || nullable || nullable == null) && !removeNullability;
+
+      tsTypeName = wrapInOption(tsTypeName, shouldWrapInOption);
 
       if (addNullability || removeNullability) {
         returnName = returnName.slice(0, -1);
@@ -178,11 +313,29 @@ export async function queryToTypeDeclarations(
 
   const { params } = paramMetadata;
   for (const param of paramMetadata.mapping) {
-    if (
+    if (param.type === 'inputTypeReference') {
+      const inputTypeInfo = inputTypes?.[param.assignedIndex];
+      if (inputTypeInfo) {
+        const recordTypeName = inputTypeNames[param.assignedIndex];
+        if (recordTypeName) {
+          paramFieldTypes.push({
+            fieldName: param.name,
+            fieldType: wrapInArray(recordTypeName, inputTypeInfo.multi),
+          });
+          continue;
+        }
+      }
+      // Fallback if input type info is not available
+      paramFieldTypes.push({
+        fieldName: param.name,
+        fieldType: 'unknown',
+      });
+    } else if (
       param.type === ParameterTransform.Scalar ||
       param.type === ParameterTransform.Spread
     ) {
       const isArray = param.type === ParameterTransform.Spread;
+
       const assignedIndex =
         param.assignedIndex instanceof Array
           ? param.assignedIndex[0]
@@ -198,31 +351,27 @@ export async function queryToTypeDeclarations(
       const optional =
         param.type === ParameterTransform.Scalar && !param.required;
 
+      tsTypeName = wrapInArray(tsTypeName, isArray);
+
       paramFieldTypes.push({
         optional,
         fieldName: param.name,
-        fieldType: isArray ? `array<${tsTypeName}>` : tsTypeName,
+        fieldType: tsTypeName,
       });
     } else {
       const isArray = param.type === ParameterTransform.PickSpread;
-      let fieldType = Object.values(param.dict)
-        .map((p) => {
-          const paramType = types.use(
-            params[p.assignedIndex - 1],
-            TypeScope.Parameter,
-          );
-          return p.required
-            ? `  ${getFieldName(p.name)}: ${paramType}`
-            : `  ${getFieldName(p.name)}?: ${paramType}`;
-        })
-        .join(',\n');
-      fieldType = `{\n${fieldType}\n}\n`;
-      const name = `${interfacePrefix}${interfaceName}Params_${param.name}`;
+      const recordFields = Object.values(param.dict).map((p) => ({
+        name: p.name,
+        type: types.use(params[p.assignedIndex - 1], TypeScope.Parameter),
+        required: p.required,
+      }));
+
+      let fieldType = generateRecordType(recordFields);
+      const name = `${interfaceName}Params_${param.name}`;
       records.push(`@gentype\ntype ${name} = ${fieldType}`);
       fieldType = name;
-      if (isArray) {
-        fieldType = `array<${fieldType}>`;
-      }
+      fieldType = wrapInArray(fieldType, isArray);
+
       paramFieldTypes.push({
         fieldName: param.name,
         fieldType,
@@ -236,36 +385,36 @@ export async function queryToTypeDeclarations(
   // tslint:disable-next-line:no-console
   types.errors.forEach((err) => console.log(err));
 
-  const resultInterfaceName = `${interfacePrefix}${interfaceName}Result`;
+  const resultInterfaceName = `${interfaceName}Result`;
   const returnTypesInterface =
     `/** '${queryName}' return type */\n` +
     (returnFieldTypes.length > 0
-      ? generateInterface(
-          `${interfacePrefix}${interfaceName}Result`,
-          returnFieldTypes,
-        )
+      ? generateInterface(`${interfaceName}Result`, returnFieldTypes)
       : generateTypeAlias(resultInterfaceName, 'unit'));
 
-  const paramInterfaceName = `${interfacePrefix}${interfaceName}Params`;
+  const paramInterfaceName = `${interfaceName}Params`;
   const paramTypesInterface =
-    `${records.join('\n')}/** '${queryName}' parameters type */\n` +
+    `${records.join('\n')}\n/** '${queryName}' parameters type */\n` +
     (paramFieldTypes.length > 0
-      ? generateInterface(
-          `${interfacePrefix}${interfaceName}Params`,
-          paramFieldTypes,
-        )
+      ? generateInterface(`${interfaceName}Params`, paramFieldTypes)
       : generateTypeAlias(paramInterfaceName, 'unit'));
 
   const typePairInterface =
     `/** '${queryName}' query type */\n` +
-    generateInterface(`${interfacePrefix}${interfaceName}Query`, [
+    generateInterface(`${interfaceName}Query`, [
       { fieldName: 'params', fieldType: paramInterfaceName },
       { fieldName: 'result', fieldType: resultInterfaceName },
     ]);
 
-  return [paramTypesInterface, returnTypesInterface, typePairInterface].join(
-    '',
-  );
+  return {
+    result: [paramTypesInterface, returnTypesInterface, typePairInterface].join(
+      '',
+    ),
+    inputParamTransforms:
+      Object.keys(inputParamTransforms).length > 0
+        ? inputParamTransforms
+        : null,
+  };
 }
 
 type ITypedQuery =
@@ -317,18 +466,19 @@ async function generateTypedecsFromFile(
     let typedQuery: ITypedQuery;
 
     const sqlQueryAST = queryAST as SQLQueryAST;
-    const result = await queryToTypeDeclarations(
+    const { result, inputParamTransforms } = await queryToTypeDeclarations(
       { ast: sqlQueryAST, mode: ProcessingMode.SQL },
       typeSource,
       types,
       config,
     );
+    const ir = queryASTToIR(sqlQueryAST, inputParamTransforms);
     typedQuery = {
       mode: 'sql' as const,
       query: {
         name: camelCase(sqlQueryAST.name),
         ast: sqlQueryAST,
-        ir: queryASTToIR(sqlQueryAST),
+        ir,
         paramTypeAlias: toRescriptName(
           `${interfacePrefix}${pascalCase(sqlQueryAST.name)}Params`,
         ),
@@ -455,61 +605,8 @@ module ${
   }
 }
 
-@gentype
-@deprecated("Use '${
-      typeDec.query.name.slice(0, 1).toUpperCase() + typeDec.query.name.slice(1)
-    }.many' directly instead")
-let ${typeDec.query.name} = (params, ~client) => ${
-      typeDec.query.name.slice(0, 1).toUpperCase() + typeDec.query.name.slice(1)
-    }.many(client, params)
-
 
 `;
   }
   return { declarationFileContents, typeDecs };
-}
-
-function toRescriptName(name: string): string {
-  if (name == null || name.length === 0) {
-    return name;
-  }
-
-  return `${name[0]?.toLowerCase() ?? ''}${name.slice(1)}`;
-}
-
-const reservedReScriptWords = [
-  'and',
-  'as',
-  'assert',
-  'await',
-  'constraint',
-  'else',
-  'exception',
-  'external',
-  'false',
-  'for',
-  'if',
-  'in',
-  'include',
-  'let',
-  'module',
-  'mutable',
-  'of',
-  'open',
-  'private',
-  'rec',
-  'switch',
-  'true',
-  'try',
-  'type',
-  'when',
-  'while',
-];
-
-function getFieldName(fieldName: string): string {
-  if (reservedReScriptWords.includes(fieldName)) {
-    return `@as("${fieldName}") ${fieldName}_`;
-  }
-
-  return fieldName;
 }

--- a/packages/cli/src/generator.ts
+++ b/packages/cli/src/generator.ts
@@ -353,6 +353,14 @@ export async function queryToTypeDeclarations(
 
       tsTypeName = wrapInArray(tsTypeName, isArray);
 
+      // Make sure any JSON.t or array of JSON is stringified, since Postgres otherwise might
+      // treat it as a Postgres array.
+      if (tsTypeName === 'JSON.t' || tsTypeName === 'array<JSON.t>') {
+        inputParamTransforms[param.assignedIndex.toString()] = {
+          type: 'stringify',
+        };
+      }
+
       paramFieldTypes.push({
         optional,
         fieldName: param.name,

--- a/packages/example/sql/schema.sql
+++ b/packages/example/sql/schema.sql
@@ -13,6 +13,11 @@ COMMENT ON COLUMN users.age IS 'Age (in years)';
 CREATE TYPE notification_type AS ENUM ('notification', 'reminder', 'deadline');
 CREATE TYPE category AS ENUM ('thriller', 'science-fiction', 'novel');
 
+CREATE TYPE some_record as (
+  id integer,
+  name text
+);
+
 CREATE TABLE notifications (
   id SERIAL PRIMARY KEY,
   user_id INTEGER REFERENCES users,

--- a/packages/example/src/books/BookService.res
+++ b/packages/example/src/books/BookService.res
@@ -17,3 +17,32 @@ let booksByAuthor = (client, ~authorName) => {
 
   client->query({authorName: authorName})
 }
+
+let insertBooks = (client, ~books) => {
+  let query = %sql.many(`
+    /* @name InsertBooks */
+      insert into books (
+      name, 
+      author_id, 
+      categories, 
+      rank
+    )
+      select
+        event.name,
+        event.author_id,
+        event.categories,
+        event.rank
+    from json_populate_recordset(
+      null::books,
+      :books!
+    ) as event
+    on conflict (id) do update set 
+      name = excluded.name,
+      author_id = excluded.author_id,
+      categories = excluded.categories,
+      rank = excluded.rank
+    returning *
+  `)
+
+  client->query({books: books})
+}

--- a/packages/example/src/books/BookServiceParams2__sql.gen.tsx
+++ b/packages/example/src/books/BookServiceParams2__sql.gen.tsx
@@ -38,8 +38,6 @@ export const Query1_expectOne: (_1:PgTyped_Pg_Client_t, _2:query1Params, errorMe
 /** Executes the query, but ignores whatever is returned by it. */
 export const Query1_execute: (_1:PgTyped_Pg_Client_t, _2:query1Params) => Promise<void> = BookServiceParams2__sqlJS.Query1.execute as any;
 
-export const query1: (params:query1Params, client:PgTyped_Pg_Client_t) => Promise<query1Result[]> = BookServiceParams2__sqlJS.query1 as any;
-
 export const Query1: {
   /** Returns exactly 1 result. Raises `Exn.t` (with an optionally provided `errorMessage`) if more or less than exactly 1 result is returned. */
   expectOne: (_1:PgTyped_Pg_Client_t, _2:query1Params, errorMessage:(undefined | string)) => Promise<query1Result>; 

--- a/packages/example/src/books/BookServiceParams2__sql.res
+++ b/packages/example/src/books/BookServiceParams2__sql.res
@@ -83,8 +83,4 @@ module Query1: {
   }
 }
 
-@gentype
-@deprecated("Use 'Query1.many' directly instead")
-let query1 = (params, ~client) => Query1.many(client, params)
-
 

--- a/packages/example/src/books/BookServiceParams__sql.gen.tsx
+++ b/packages/example/src/books/BookServiceParams__sql.gen.tsx
@@ -38,8 +38,6 @@ export const Query1_expectOne: (_1:PgTyped_Pg_Client_t, _2:query1Params, errorMe
 /** Executes the query, but ignores whatever is returned by it. */
 export const Query1_execute: (_1:PgTyped_Pg_Client_t, _2:query1Params) => Promise<void> = BookServiceParams__sqlJS.Query1.execute as any;
 
-export const query1: (params:query1Params, client:PgTyped_Pg_Client_t) => Promise<query1Result[]> = BookServiceParams__sqlJS.query1 as any;
-
 export const Query1: {
   /** Returns exactly 1 result. Raises `Exn.t` (with an optionally provided `errorMessage`) if more or less than exactly 1 result is returned. */
   expectOne: (_1:PgTyped_Pg_Client_t, _2:query1Params, errorMessage:(undefined | string)) => Promise<query1Result>; 

--- a/packages/example/src/books/BookServiceParams__sql.res
+++ b/packages/example/src/books/BookServiceParams__sql.res
@@ -83,8 +83,4 @@ module Query1: {
   }
 }
 
-@gentype
-@deprecated("Use 'Query1.many' directly instead")
-let query1 = (params, ~client) => Query1.many(client, params)
-
 

--- a/packages/example/src/books/BookService__sql.gen.tsx
+++ b/packages/example/src/books/BookService__sql.gen.tsx
@@ -41,6 +41,29 @@ export type booksByAuthorResult = {
 /** 'BooksByAuthor' query type */
 export type booksByAuthorQuery = { readonly params: booksByAuthorParams; readonly result: booksByAuthorResult };
 
+export type insertBooks_booksInputType = {
+  readonly author_id?: number; 
+  readonly categories?: categoryArray; 
+  readonly id?: number; 
+  readonly name?: string; 
+  readonly rank?: number
+};
+
+/** 'InsertBooks' parameters type */
+export type insertBooksParams = { readonly books: insertBooks_booksInputType[] };
+
+/** 'InsertBooks' return type */
+export type insertBooksResult = {
+  readonly author_id: (undefined | number); 
+  readonly categories: (undefined | categoryArray); 
+  readonly id: number; 
+  readonly name: (undefined | string); 
+  readonly rank: (undefined | number)
+};
+
+/** 'InsertBooks' query type */
+export type insertBooksQuery = { readonly params: insertBooksParams; readonly result: insertBooksResult };
+
 /** Returns an array of all matched results. */
 export const FindBookById_many: (_1:PgTyped_Pg_Client_t, _2:findBookByIdParams) => Promise<findBookByIdResult[]> = BookService__sqlJS.FindBookById.many as any;
 
@@ -52,8 +75,6 @@ export const FindBookById_expectOne: (_1:PgTyped_Pg_Client_t, _2:findBookByIdPar
 
 /** Executes the query, but ignores whatever is returned by it. */
 export const FindBookById_execute: (_1:PgTyped_Pg_Client_t, _2:findBookByIdParams) => Promise<void> = BookService__sqlJS.FindBookById.execute as any;
-
-export const findBookById: (params:findBookByIdParams, client:PgTyped_Pg_Client_t) => Promise<findBookByIdResult[]> = BookService__sqlJS.findBookById as any;
 
 /** Returns an array of all matched results. */
 export const BooksByAuthor_many: (_1:PgTyped_Pg_Client_t, _2:booksByAuthorParams) => Promise<booksByAuthorResult[]> = BookService__sqlJS.BooksByAuthor.many as any;
@@ -67,7 +88,17 @@ export const BooksByAuthor_expectOne: (_1:PgTyped_Pg_Client_t, _2:booksByAuthorP
 /** Executes the query, but ignores whatever is returned by it. */
 export const BooksByAuthor_execute: (_1:PgTyped_Pg_Client_t, _2:booksByAuthorParams) => Promise<void> = BookService__sqlJS.BooksByAuthor.execute as any;
 
-export const booksByAuthor: (params:booksByAuthorParams, client:PgTyped_Pg_Client_t) => Promise<booksByAuthorResult[]> = BookService__sqlJS.booksByAuthor as any;
+/** Returns an array of all matched results. */
+export const InsertBooks_many: (_1:PgTyped_Pg_Client_t, _2:insertBooksParams) => Promise<insertBooksResult[]> = BookService__sqlJS.InsertBooks.many as any;
+
+/** Returns exactly 1 result. Returns `None` if more or less than exactly 1 result is returned. */
+export const InsertBooks_one: (_1:PgTyped_Pg_Client_t, _2:insertBooksParams) => Promise<(undefined | insertBooksResult)> = BookService__sqlJS.InsertBooks.one as any;
+
+/** Returns exactly 1 result. Raises `Exn.t` (with an optionally provided `errorMessage`) if more or less than exactly 1 result is returned. */
+export const InsertBooks_expectOne: (_1:PgTyped_Pg_Client_t, _2:insertBooksParams, errorMessage:(undefined | string)) => Promise<insertBooksResult> = BookService__sqlJS.InsertBooks.expectOne as any;
+
+/** Executes the query, but ignores whatever is returned by it. */
+export const InsertBooks_execute: (_1:PgTyped_Pg_Client_t, _2:insertBooksParams) => Promise<void> = BookService__sqlJS.InsertBooks.execute as any;
 
 export const FindBookById: {
   /** Returns exactly 1 result. Raises `Exn.t` (with an optionally provided `errorMessage`) if more or less than exactly 1 result is returned. */
@@ -90,3 +121,14 @@ export const BooksByAuthor: {
   /** Executes the query, but ignores whatever is returned by it. */
   execute: (_1:PgTyped_Pg_Client_t, _2:booksByAuthorParams) => Promise<void>
 } = BookService__sqlJS.BooksByAuthor as any;
+
+export const InsertBooks: {
+  /** Returns exactly 1 result. Raises `Exn.t` (with an optionally provided `errorMessage`) if more or less than exactly 1 result is returned. */
+  expectOne: (_1:PgTyped_Pg_Client_t, _2:insertBooksParams, errorMessage:(undefined | string)) => Promise<insertBooksResult>; 
+  /** Returns exactly 1 result. Returns `None` if more or less than exactly 1 result is returned. */
+  one: (_1:PgTyped_Pg_Client_t, _2:insertBooksParams) => Promise<(undefined | insertBooksResult)>; 
+  /** Returns an array of all matched results. */
+  many: (_1:PgTyped_Pg_Client_t, _2:insertBooksParams) => Promise<insertBooksResult[]>; 
+  /** Executes the query, but ignores whatever is returned by it. */
+  execute: (_1:PgTyped_Pg_Client_t, _2:insertBooksParams) => Promise<void>
+} = BookService__sqlJS.InsertBooks as any;

--- a/packages/example/src/books/BookService__sql.res
+++ b/packages/example/src/books/BookService__sql.res
@@ -8,6 +8,7 @@ type category = [#"novel" | #"science-fiction" | #"thriller"]
 @gentype
 type categoryArray = array<category>
 
+
 /** 'FindBookById' parameters type */
 @gentype
 type findBookByIdParams = {
@@ -86,9 +87,6 @@ module FindBookById: {
   }
 }
 
-@gentype
-@deprecated("Use 'FindBookById.many' directly instead")
-let findBookById = (params, ~client) => FindBookById.many(client, params)
 
 
 /** 'BooksByAuthor' parameters type */
@@ -171,8 +169,113 @@ module BooksByAuthor: {
   }
 }
 
+
 @gentype
-@deprecated("Use 'BooksByAuthor.many' directly instead")
-let booksByAuthor = (params, ~client) => BooksByAuthor.many(client, params)
+type insertBooks_booksInputType = {
+  author_id?: int,
+  categories?: categoryArray,
+  id?: int,
+  name?: string,
+  rank?: int,
+}
+
+
+/** 'InsertBooks' parameters type */
+@gentype
+type insertBooksParams = {
+  books: array<insertBooks_booksInputType>,
+}
+
+/** 'InsertBooks' return type */
+@gentype
+type insertBooksResult = {
+  author_id: option<int>,
+  categories: option<categoryArray>,
+  id: int,
+  name: option<string>,
+  rank: option<int>,
+}
+
+/** 'InsertBooks' query type */
+@gentype
+type insertBooksQuery = {
+  params: insertBooksParams,
+  result: insertBooksResult,
+}
+
+%%private(let insertBooksIR: IR.t = %raw(`{"queryName":"InsertBooks","inputParamTransforms":{"1":{"type":"stringify"}},"usedParamSet":{"books":true},"params":[{"name":"books","required":true,"transform":{"type":"scalar"},"locs":[{"a":249,"b":255}]}],"statement":"insert into books (\n      name, \n      author_id, \n      categories, \n      rank\n    )\n      select\n        event.name,\n        event.author_id,\n        event.categories,\n        event.rank\n    from json_populate_recordset(\n      null::books,\n      :books!\n    ) as event\n    on conflict (id) do update set \n      name = excluded.name,\n      author_id = excluded.author_id,\n      categories = excluded.categories,\n      rank = excluded.rank\n    returning *"}`))
+
+/**
+ Runnable query:
+ ```sql
+insert into books (
+      name, 
+      author_id, 
+      categories, 
+      rank
+    )
+      select
+        event.name,
+        event.author_id,
+        event.categories,
+        event.rank
+    from json_populate_recordset(
+      null::books,
+      $1
+    ) as event
+    on conflict (id) do update set 
+      name = excluded.name,
+      author_id = excluded.author_id,
+      categories = excluded.categories,
+      rank = excluded.rank
+    returning *
+ ```
+
+ */
+@gentype
+module InsertBooks: {
+  /** Returns an array of all matched results. */
+  @gentype
+  let many: (PgTyped.Pg.Client.t, insertBooksParams) => promise<array<insertBooksResult>>
+  /** Returns exactly 1 result. Returns `None` if more or less than exactly 1 result is returned. */
+  @gentype
+  let one: (PgTyped.Pg.Client.t, insertBooksParams) => promise<option<insertBooksResult>>
+  
+  /** Returns exactly 1 result. Raises `Exn.t` (with an optionally provided `errorMessage`) if more or less than exactly 1 result is returned. */
+  @gentype
+  let expectOne: (
+    PgTyped.Pg.Client.t,
+    insertBooksParams,
+    ~errorMessage: string=?
+  ) => promise<insertBooksResult>
+
+  /** Executes the query, but ignores whatever is returned by it. */
+  @gentype
+  let execute: (PgTyped.Pg.Client.t, insertBooksParams) => promise<unit>
+} = {
+  @module("pgtyped-rescript-runtime") @new external insertBooks: IR.t => PreparedStatement.t<insertBooksParams, insertBooksResult> = "PreparedQuery";
+  let query = insertBooks(insertBooksIR)
+  let query = (params, ~client) => query->PreparedStatement.run(params, ~client)
+
+  @gentype
+  let many = (client, params) => query(params, ~client)
+
+  @gentype
+  let one = async (client, params) => switch await query(params, ~client) {
+  | [item] => Some(item)
+  | _ => None
+  }
+
+  @gentype
+  let expectOne = async (client, params, ~errorMessage=?) => switch await query(params, ~client) {
+  | [item] => item
+  | _ => panic(errorMessage->Option.getOr("More or less than one item was returned"))
+  }
+
+  @gentype
+  let execute = async (client, params) => {
+    let _ = await query(params, ~client)
+  }
+}
 
 

--- a/packages/example/src/books/Dump__sql.gen.tsx
+++ b/packages/example/src/books/Dump__sql.gen.tsx
@@ -88,8 +88,6 @@ export const Dump_expectOne: (_1:PgTyped_Pg_Client_t, _2:dumpParams, errorMessag
 /** Executes the query, but ignores whatever is returned by it. */
 export const Dump_execute: (_1:PgTyped_Pg_Client_t, _2:dumpParams) => Promise<void> = Dump__sqlJS.Dump.execute as any;
 
-export const dump: (params:dumpParams, client:PgTyped_Pg_Client_t) => Promise<dumpResult[]> = Dump__sqlJS.dump as any;
-
 export const Dump: {
   /** Returns exactly 1 result. Raises `Exn.t` (with an optionally provided `errorMessage`) if more or less than exactly 1 result is returned. */
   expectOne: (_1:PgTyped_Pg_Client_t, _2:dumpParams, errorMessage:(undefined | string)) => Promise<dumpResult>; 

--- a/packages/example/src/books/Dump__sql.res
+++ b/packages/example/src/books/Dump__sql.res
@@ -5,6 +5,7 @@ open PgTyped
 @gentype
 type arrayJSON_t = array<JSON.t>
 
+
 /** 'Dump' parameters type */
 @gentype
 type dumpParams = unit
@@ -97,9 +98,5 @@ module Dump: {
     let _ = await query(params, ~client)
   }
 }
-
-@gentype
-@deprecated("Use 'Dump.many' directly instead")
-let dump = (params, ~client) => Dump.many(client, params)
 
 

--- a/packages/example/src/books/Json.res
+++ b/packages/example/src/books/Json.res
@@ -11,6 +11,11 @@ module JsonExtract = %sql(`
   FROM json_array_elements(:jsonData!::json) AS value
 `)
 
+let jsonUnnestCast = %sql.one(`
+  /* @name JsonUnnestCast */
+  SELECT unnest(:jsonData!::json[]) AS json_arr;
+`)
+
 let jsonPopulateRecordQuery = %sql.one(`
   /* @name JsonPopulateRecord */
   SELECT * FROM json_populate_record(

--- a/packages/example/src/books/Json.res
+++ b/packages/example/src/books/Json.res
@@ -3,6 +3,14 @@ let query = %sql.one(`
   SELECT json_build_object('key', 'value') AS json_object;
 `)
 
+let jsonPopulateRecordQuery = %sql.one(`
+  /* @name JsonPopulateRecord */
+  SELECT * FROM json_populate_record(
+    null::books,
+    :book!
+  );
+`)
+
 let jsonPopulateRecordsetQuery = %sql.one(`
   /* @name JsonPopulateRecordset */
   insert into books (
@@ -51,4 +59,20 @@ let jsonPopulateRecordsetJsonCastQuery = %sql.one(`
     categories = excluded.categories,
     rank = excluded.rank
   returning *
+`)
+
+let jsonbPopulateRecordQuery = %sql.one(`
+  /* @name JsonbPopulateRecord */
+  SELECT * FROM jsonb_populate_record(
+    null::books,
+    :book!
+  );
+`)
+
+let jsonbPopulateRecordsetQuery = %sql.one(`
+  /* @name JsonbPopulateRecordset */
+  SELECT * FROM jsonb_populate_recordset(
+    null::books,
+    :books!
+  );
 `)

--- a/packages/example/src/books/Json.res
+++ b/packages/example/src/books/Json.res
@@ -3,6 +3,14 @@ let query = %sql.one(`
   SELECT json_build_object('key', 'value') AS json_object;
 `)
 
+module JsonExtract = %sql(`
+  /* @name JsonExtract */
+  SELECT 
+    value->>'name' AS user_name,
+    value->>'id' AS user_id
+  FROM json_array_elements(:jsonData!::json) AS value
+`)
+
 let jsonPopulateRecordQuery = %sql.one(`
   /* @name JsonPopulateRecord */
   SELECT * FROM json_populate_record(

--- a/packages/example/src/books/Json.res
+++ b/packages/example/src/books/Json.res
@@ -2,3 +2,53 @@ let query = %sql.one(`
   /* @name Json */
   SELECT json_build_object('key', 'value') AS json_object;
 `)
+
+let jsonPopulateRecordsetQuery = %sql.one(`
+  /* @name JsonPopulateRecordset */
+  insert into books (
+    name, 
+    author_id, 
+    categories, 
+    rank
+  )
+    select
+      event.name,
+      event.author_id,
+      event.categories,
+      event.rank
+  from json_populate_recordset(
+    null::books,
+    :books!
+  ) as event
+  on conflict (id) do update set 
+    name = excluded.name,
+    author_id = excluded.author_id,
+    categories = excluded.categories,
+    rank = excluded.rank
+  returning *
+`)
+
+let jsonPopulateRecordsetJsonCastQuery = %sql.one(`
+  /* @name JsonPopulateRecordsetJsonCast */
+  insert into books (
+    name, 
+    author_id, 
+    categories, 
+    rank
+  )
+    select
+      event.name,
+      event.author_id,
+      event.categories,
+      event.rank
+  from json_populate_recordset(
+    null::books,
+    :books!::json
+  ) as event
+  on conflict (id) do update set 
+    name = excluded.name,
+    author_id = excluded.author_id,
+    categories = excluded.categories,
+    rank = excluded.rank
+  returning *
+`)

--- a/packages/example/src/books/Json__sql.gen.tsx
+++ b/packages/example/src/books/Json__sql.gen.tsx
@@ -11,6 +11,8 @@ import type {t as JSON_t} from './JSON.gen';
 
 export type category = "novel" | "science-fiction" | "thriller";
 
+export type arrayJSON_t = JSON_t[];
+
 export type categoryArray = category[];
 
 /** 'Json' parameters type */
@@ -30,6 +32,15 @@ export type jsonExtractResult = { readonly user_id: (undefined | string); readon
 
 /** 'JsonExtract' query type */
 export type jsonExtractQuery = { readonly params: jsonExtractParams; readonly result: jsonExtractResult };
+
+/** 'JsonUnnestCast' parameters type */
+export type jsonUnnestCastParams = { readonly jsonData: arrayJSON_t };
+
+/** 'JsonUnnestCast' return type */
+export type jsonUnnestCastResult = { readonly json_arr: (undefined | JSON_t) };
+
+/** 'JsonUnnestCast' query type */
+export type jsonUnnestCastQuery = { readonly params: jsonUnnestCastParams; readonly result: jsonUnnestCastResult };
 
 export type jsonPopulateRecord_booksInputType = {
   readonly author_id?: number; 
@@ -163,6 +174,18 @@ export const JsonExtract_expectOne: (_1:PgTyped_Pg_Client_t, _2:jsonExtractParam
 export const JsonExtract_execute: (_1:PgTyped_Pg_Client_t, _2:jsonExtractParams) => Promise<void> = Json__sqlJS.JsonExtract.execute as any;
 
 /** Returns an array of all matched results. */
+export const JsonUnnestCast_many: (_1:PgTyped_Pg_Client_t, _2:jsonUnnestCastParams) => Promise<jsonUnnestCastResult[]> = Json__sqlJS.JsonUnnestCast.many as any;
+
+/** Returns exactly 1 result. Returns `None` if more or less than exactly 1 result is returned. */
+export const JsonUnnestCast_one: (_1:PgTyped_Pg_Client_t, _2:jsonUnnestCastParams) => Promise<(undefined | jsonUnnestCastResult)> = Json__sqlJS.JsonUnnestCast.one as any;
+
+/** Returns exactly 1 result. Raises `Exn.t` (with an optionally provided `errorMessage`) if more or less than exactly 1 result is returned. */
+export const JsonUnnestCast_expectOne: (_1:PgTyped_Pg_Client_t, _2:jsonUnnestCastParams, errorMessage:(undefined | string)) => Promise<jsonUnnestCastResult> = Json__sqlJS.JsonUnnestCast.expectOne as any;
+
+/** Executes the query, but ignores whatever is returned by it. */
+export const JsonUnnestCast_execute: (_1:PgTyped_Pg_Client_t, _2:jsonUnnestCastParams) => Promise<void> = Json__sqlJS.JsonUnnestCast.execute as any;
+
+/** Returns an array of all matched results. */
 export const JsonPopulateRecord_many: (_1:PgTyped_Pg_Client_t, _2:jsonPopulateRecordParams) => Promise<jsonPopulateRecordResult[]> = Json__sqlJS.JsonPopulateRecord.many as any;
 
 /** Returns exactly 1 result. Returns `None` if more or less than exactly 1 result is returned. */
@@ -287,6 +310,17 @@ export const Json: {
   /** Executes the query, but ignores whatever is returned by it. */
   execute: (_1:PgTyped_Pg_Client_t, _2:jsonParams) => Promise<void>
 } = Json__sqlJS.Json as any;
+
+export const JsonUnnestCast: {
+  /** Returns exactly 1 result. Raises `Exn.t` (with an optionally provided `errorMessage`) if more or less than exactly 1 result is returned. */
+  expectOne: (_1:PgTyped_Pg_Client_t, _2:jsonUnnestCastParams, errorMessage:(undefined | string)) => Promise<jsonUnnestCastResult>; 
+  /** Returns exactly 1 result. Returns `None` if more or less than exactly 1 result is returned. */
+  one: (_1:PgTyped_Pg_Client_t, _2:jsonUnnestCastParams) => Promise<(undefined | jsonUnnestCastResult)>; 
+  /** Returns an array of all matched results. */
+  many: (_1:PgTyped_Pg_Client_t, _2:jsonUnnestCastParams) => Promise<jsonUnnestCastResult[]>; 
+  /** Executes the query, but ignores whatever is returned by it. */
+  execute: (_1:PgTyped_Pg_Client_t, _2:jsonUnnestCastParams) => Promise<void>
+} = Json__sqlJS.JsonUnnestCast as any;
 
 export const JsonPopulateRecordsetJsonCast: {
   /** Returns exactly 1 result. Raises `Exn.t` (with an optionally provided `errorMessage`) if more or less than exactly 1 result is returned. */

--- a/packages/example/src/books/Json__sql.gen.tsx
+++ b/packages/example/src/books/Json__sql.gen.tsx
@@ -9,6 +9,10 @@ import type {Pg_Client_t as PgTyped_Pg_Client_t} from 'pgtyped-rescript/src/res/
 
 import type {t as JSON_t} from './JSON.gen';
 
+export type category = "novel" | "science-fiction" | "thriller";
+
+export type categoryArray = category[];
+
 /** 'Json' parameters type */
 export type jsonParams = void;
 
@@ -17,6 +21,44 @@ export type jsonResult = { readonly json_object: (undefined | JSON_t) };
 
 /** 'Json' query type */
 export type jsonQuery = { readonly params: jsonParams; readonly result: jsonResult };
+
+export type jsonPopulateRecordset_booksInputType = {
+  readonly author_id?: number; 
+  readonly categories?: categoryArray; 
+  readonly id?: number; 
+  readonly name?: string; 
+  readonly rank?: number
+};
+
+/** 'JsonPopulateRecordset' parameters type */
+export type jsonPopulateRecordsetParams = { readonly books: jsonPopulateRecordset_booksInputType[] };
+
+/** 'JsonPopulateRecordset' return type */
+export type jsonPopulateRecordsetResult = {
+  readonly author_id: (undefined | number); 
+  readonly categories: (undefined | categoryArray); 
+  readonly id: number; 
+  readonly name: (undefined | string); 
+  readonly rank: (undefined | number)
+};
+
+/** 'JsonPopulateRecordset' query type */
+export type jsonPopulateRecordsetQuery = { readonly params: jsonPopulateRecordsetParams; readonly result: jsonPopulateRecordsetResult };
+
+/** 'JsonPopulateRecordsetJsonCast' parameters type */
+export type jsonPopulateRecordsetJsonCastParams = { readonly books: JSON_t };
+
+/** 'JsonPopulateRecordsetJsonCast' return type */
+export type jsonPopulateRecordsetJsonCastResult = {
+  readonly author_id: (undefined | number); 
+  readonly categories: (undefined | categoryArray); 
+  readonly id: number; 
+  readonly name: (undefined | string); 
+  readonly rank: (undefined | number)
+};
+
+/** 'JsonPopulateRecordsetJsonCast' query type */
+export type jsonPopulateRecordsetJsonCastQuery = { readonly params: jsonPopulateRecordsetJsonCastParams; readonly result: jsonPopulateRecordsetJsonCastResult };
 
 /** Returns an array of all matched results. */
 export const Json_many: (_1:PgTyped_Pg_Client_t, _2:jsonParams) => Promise<jsonResult[]> = Json__sqlJS.Json.many as any;
@@ -30,7 +72,40 @@ export const Json_expectOne: (_1:PgTyped_Pg_Client_t, _2:jsonParams, errorMessag
 /** Executes the query, but ignores whatever is returned by it. */
 export const Json_execute: (_1:PgTyped_Pg_Client_t, _2:jsonParams) => Promise<void> = Json__sqlJS.Json.execute as any;
 
-export const json: (params:jsonParams, client:PgTyped_Pg_Client_t) => Promise<jsonResult[]> = Json__sqlJS.json as any;
+/** Returns an array of all matched results. */
+export const JsonPopulateRecordset_many: (_1:PgTyped_Pg_Client_t, _2:jsonPopulateRecordsetParams) => Promise<jsonPopulateRecordsetResult[]> = Json__sqlJS.JsonPopulateRecordset.many as any;
+
+/** Returns exactly 1 result. Returns `None` if more or less than exactly 1 result is returned. */
+export const JsonPopulateRecordset_one: (_1:PgTyped_Pg_Client_t, _2:jsonPopulateRecordsetParams) => Promise<(undefined | jsonPopulateRecordsetResult)> = Json__sqlJS.JsonPopulateRecordset.one as any;
+
+/** Returns exactly 1 result. Raises `Exn.t` (with an optionally provided `errorMessage`) if more or less than exactly 1 result is returned. */
+export const JsonPopulateRecordset_expectOne: (_1:PgTyped_Pg_Client_t, _2:jsonPopulateRecordsetParams, errorMessage:(undefined | string)) => Promise<jsonPopulateRecordsetResult> = Json__sqlJS.JsonPopulateRecordset.expectOne as any;
+
+/** Executes the query, but ignores whatever is returned by it. */
+export const JsonPopulateRecordset_execute: (_1:PgTyped_Pg_Client_t, _2:jsonPopulateRecordsetParams) => Promise<void> = Json__sqlJS.JsonPopulateRecordset.execute as any;
+
+/** Returns an array of all matched results. */
+export const JsonPopulateRecordsetJsonCast_many: (_1:PgTyped_Pg_Client_t, _2:jsonPopulateRecordsetJsonCastParams) => Promise<jsonPopulateRecordsetJsonCastResult[]> = Json__sqlJS.JsonPopulateRecordsetJsonCast.many as any;
+
+/** Returns exactly 1 result. Returns `None` if more or less than exactly 1 result is returned. */
+export const JsonPopulateRecordsetJsonCast_one: (_1:PgTyped_Pg_Client_t, _2:jsonPopulateRecordsetJsonCastParams) => Promise<(undefined | jsonPopulateRecordsetJsonCastResult)> = Json__sqlJS.JsonPopulateRecordsetJsonCast.one as any;
+
+/** Returns exactly 1 result. Raises `Exn.t` (with an optionally provided `errorMessage`) if more or less than exactly 1 result is returned. */
+export const JsonPopulateRecordsetJsonCast_expectOne: (_1:PgTyped_Pg_Client_t, _2:jsonPopulateRecordsetJsonCastParams, errorMessage:(undefined | string)) => Promise<jsonPopulateRecordsetJsonCastResult> = Json__sqlJS.JsonPopulateRecordsetJsonCast.expectOne as any;
+
+/** Executes the query, but ignores whatever is returned by it. */
+export const JsonPopulateRecordsetJsonCast_execute: (_1:PgTyped_Pg_Client_t, _2:jsonPopulateRecordsetJsonCastParams) => Promise<void> = Json__sqlJS.JsonPopulateRecordsetJsonCast.execute as any;
+
+export const JsonPopulateRecordset: {
+  /** Returns exactly 1 result. Raises `Exn.t` (with an optionally provided `errorMessage`) if more or less than exactly 1 result is returned. */
+  expectOne: (_1:PgTyped_Pg_Client_t, _2:jsonPopulateRecordsetParams, errorMessage:(undefined | string)) => Promise<jsonPopulateRecordsetResult>; 
+  /** Returns exactly 1 result. Returns `None` if more or less than exactly 1 result is returned. */
+  one: (_1:PgTyped_Pg_Client_t, _2:jsonPopulateRecordsetParams) => Promise<(undefined | jsonPopulateRecordsetResult)>; 
+  /** Returns an array of all matched results. */
+  many: (_1:PgTyped_Pg_Client_t, _2:jsonPopulateRecordsetParams) => Promise<jsonPopulateRecordsetResult[]>; 
+  /** Executes the query, but ignores whatever is returned by it. */
+  execute: (_1:PgTyped_Pg_Client_t, _2:jsonPopulateRecordsetParams) => Promise<void>
+} = Json__sqlJS.JsonPopulateRecordset as any;
 
 export const Json: {
   /** Returns exactly 1 result. Raises `Exn.t` (with an optionally provided `errorMessage`) if more or less than exactly 1 result is returned. */
@@ -42,3 +117,14 @@ export const Json: {
   /** Executes the query, but ignores whatever is returned by it. */
   execute: (_1:PgTyped_Pg_Client_t, _2:jsonParams) => Promise<void>
 } = Json__sqlJS.Json as any;
+
+export const JsonPopulateRecordsetJsonCast: {
+  /** Returns exactly 1 result. Raises `Exn.t` (with an optionally provided `errorMessage`) if more or less than exactly 1 result is returned. */
+  expectOne: (_1:PgTyped_Pg_Client_t, _2:jsonPopulateRecordsetJsonCastParams, errorMessage:(undefined | string)) => Promise<jsonPopulateRecordsetJsonCastResult>; 
+  /** Returns exactly 1 result. Returns `None` if more or less than exactly 1 result is returned. */
+  one: (_1:PgTyped_Pg_Client_t, _2:jsonPopulateRecordsetJsonCastParams) => Promise<(undefined | jsonPopulateRecordsetJsonCastResult)>; 
+  /** Returns an array of all matched results. */
+  many: (_1:PgTyped_Pg_Client_t, _2:jsonPopulateRecordsetJsonCastParams) => Promise<jsonPopulateRecordsetJsonCastResult[]>; 
+  /** Executes the query, but ignores whatever is returned by it. */
+  execute: (_1:PgTyped_Pg_Client_t, _2:jsonPopulateRecordsetJsonCastParams) => Promise<void>
+} = Json__sqlJS.JsonPopulateRecordsetJsonCast as any;

--- a/packages/example/src/books/Json__sql.gen.tsx
+++ b/packages/example/src/books/Json__sql.gen.tsx
@@ -22,6 +22,38 @@ export type jsonResult = { readonly json_object: (undefined | JSON_t) };
 /** 'Json' query type */
 export type jsonQuery = { readonly params: jsonParams; readonly result: jsonResult };
 
+/** 'JsonExtract' parameters type */
+export type jsonExtractParams = { readonly jsonData: JSON_t };
+
+/** 'JsonExtract' return type */
+export type jsonExtractResult = { readonly user_id: (undefined | string); readonly user_name: (undefined | string) };
+
+/** 'JsonExtract' query type */
+export type jsonExtractQuery = { readonly params: jsonExtractParams; readonly result: jsonExtractResult };
+
+export type jsonPopulateRecord_booksInputType = {
+  readonly author_id?: number; 
+  readonly categories?: categoryArray; 
+  readonly id?: number; 
+  readonly name?: string; 
+  readonly rank?: number
+};
+
+/** 'JsonPopulateRecord' parameters type */
+export type jsonPopulateRecordParams = { readonly book: jsonPopulateRecord_booksInputType };
+
+/** 'JsonPopulateRecord' return type */
+export type jsonPopulateRecordResult = {
+  readonly author_id: (undefined | number); 
+  readonly categories: (undefined | categoryArray); 
+  readonly id: (undefined | number); 
+  readonly name: (undefined | string); 
+  readonly rank: (undefined | number)
+};
+
+/** 'JsonPopulateRecord' query type */
+export type jsonPopulateRecordQuery = { readonly params: jsonPopulateRecordParams; readonly result: jsonPopulateRecordResult };
+
 export type jsonPopulateRecordset_booksInputType = {
   readonly author_id?: number; 
   readonly categories?: categoryArray; 
@@ -60,6 +92,52 @@ export type jsonPopulateRecordsetJsonCastResult = {
 /** 'JsonPopulateRecordsetJsonCast' query type */
 export type jsonPopulateRecordsetJsonCastQuery = { readonly params: jsonPopulateRecordsetJsonCastParams; readonly result: jsonPopulateRecordsetJsonCastResult };
 
+export type jsonbPopulateRecord_booksInputType = {
+  readonly author_id?: number; 
+  readonly categories?: categoryArray; 
+  readonly id?: number; 
+  readonly name?: string; 
+  readonly rank?: number
+};
+
+/** 'JsonbPopulateRecord' parameters type */
+export type jsonbPopulateRecordParams = { readonly book: jsonbPopulateRecord_booksInputType };
+
+/** 'JsonbPopulateRecord' return type */
+export type jsonbPopulateRecordResult = {
+  readonly author_id: (undefined | number); 
+  readonly categories: (undefined | categoryArray); 
+  readonly id: (undefined | number); 
+  readonly name: (undefined | string); 
+  readonly rank: (undefined | number)
+};
+
+/** 'JsonbPopulateRecord' query type */
+export type jsonbPopulateRecordQuery = { readonly params: jsonbPopulateRecordParams; readonly result: jsonbPopulateRecordResult };
+
+export type jsonbPopulateRecordset_booksInputType = {
+  readonly author_id?: number; 
+  readonly categories?: categoryArray; 
+  readonly id?: number; 
+  readonly name?: string; 
+  readonly rank?: number
+};
+
+/** 'JsonbPopulateRecordset' parameters type */
+export type jsonbPopulateRecordsetParams = { readonly books: jsonbPopulateRecordset_booksInputType[] };
+
+/** 'JsonbPopulateRecordset' return type */
+export type jsonbPopulateRecordsetResult = {
+  readonly author_id: (undefined | number); 
+  readonly categories: (undefined | categoryArray); 
+  readonly id: (undefined | number); 
+  readonly name: (undefined | string); 
+  readonly rank: (undefined | number)
+};
+
+/** 'JsonbPopulateRecordset' query type */
+export type jsonbPopulateRecordsetQuery = { readonly params: jsonbPopulateRecordsetParams; readonly result: jsonbPopulateRecordsetResult };
+
 /** Returns an array of all matched results. */
 export const Json_many: (_1:PgTyped_Pg_Client_t, _2:jsonParams) => Promise<jsonResult[]> = Json__sqlJS.Json.many as any;
 
@@ -71,6 +149,30 @@ export const Json_expectOne: (_1:PgTyped_Pg_Client_t, _2:jsonParams, errorMessag
 
 /** Executes the query, but ignores whatever is returned by it. */
 export const Json_execute: (_1:PgTyped_Pg_Client_t, _2:jsonParams) => Promise<void> = Json__sqlJS.Json.execute as any;
+
+/** Returns an array of all matched results. */
+export const JsonExtract_many: (_1:PgTyped_Pg_Client_t, _2:jsonExtractParams) => Promise<jsonExtractResult[]> = Json__sqlJS.JsonExtract.many as any;
+
+/** Returns exactly 1 result. Returns `None` if more or less than exactly 1 result is returned. */
+export const JsonExtract_one: (_1:PgTyped_Pg_Client_t, _2:jsonExtractParams) => Promise<(undefined | jsonExtractResult)> = Json__sqlJS.JsonExtract.one as any;
+
+/** Returns exactly 1 result. Raises `Exn.t` (with an optionally provided `errorMessage`) if more or less than exactly 1 result is returned. */
+export const JsonExtract_expectOne: (_1:PgTyped_Pg_Client_t, _2:jsonExtractParams, errorMessage:(undefined | string)) => Promise<jsonExtractResult> = Json__sqlJS.JsonExtract.expectOne as any;
+
+/** Executes the query, but ignores whatever is returned by it. */
+export const JsonExtract_execute: (_1:PgTyped_Pg_Client_t, _2:jsonExtractParams) => Promise<void> = Json__sqlJS.JsonExtract.execute as any;
+
+/** Returns an array of all matched results. */
+export const JsonPopulateRecord_many: (_1:PgTyped_Pg_Client_t, _2:jsonPopulateRecordParams) => Promise<jsonPopulateRecordResult[]> = Json__sqlJS.JsonPopulateRecord.many as any;
+
+/** Returns exactly 1 result. Returns `None` if more or less than exactly 1 result is returned. */
+export const JsonPopulateRecord_one: (_1:PgTyped_Pg_Client_t, _2:jsonPopulateRecordParams) => Promise<(undefined | jsonPopulateRecordResult)> = Json__sqlJS.JsonPopulateRecord.one as any;
+
+/** Returns exactly 1 result. Raises `Exn.t` (with an optionally provided `errorMessage`) if more or less than exactly 1 result is returned. */
+export const JsonPopulateRecord_expectOne: (_1:PgTyped_Pg_Client_t, _2:jsonPopulateRecordParams, errorMessage:(undefined | string)) => Promise<jsonPopulateRecordResult> = Json__sqlJS.JsonPopulateRecord.expectOne as any;
+
+/** Executes the query, but ignores whatever is returned by it. */
+export const JsonPopulateRecord_execute: (_1:PgTyped_Pg_Client_t, _2:jsonPopulateRecordParams) => Promise<void> = Json__sqlJS.JsonPopulateRecord.execute as any;
 
 /** Returns an array of all matched results. */
 export const JsonPopulateRecordset_many: (_1:PgTyped_Pg_Client_t, _2:jsonPopulateRecordsetParams) => Promise<jsonPopulateRecordsetResult[]> = Json__sqlJS.JsonPopulateRecordset.many as any;
@@ -96,6 +198,63 @@ export const JsonPopulateRecordsetJsonCast_expectOne: (_1:PgTyped_Pg_Client_t, _
 /** Executes the query, but ignores whatever is returned by it. */
 export const JsonPopulateRecordsetJsonCast_execute: (_1:PgTyped_Pg_Client_t, _2:jsonPopulateRecordsetJsonCastParams) => Promise<void> = Json__sqlJS.JsonPopulateRecordsetJsonCast.execute as any;
 
+/** Returns an array of all matched results. */
+export const JsonbPopulateRecord_many: (_1:PgTyped_Pg_Client_t, _2:jsonbPopulateRecordParams) => Promise<jsonbPopulateRecordResult[]> = Json__sqlJS.JsonbPopulateRecord.many as any;
+
+/** Returns exactly 1 result. Returns `None` if more or less than exactly 1 result is returned. */
+export const JsonbPopulateRecord_one: (_1:PgTyped_Pg_Client_t, _2:jsonbPopulateRecordParams) => Promise<(undefined | jsonbPopulateRecordResult)> = Json__sqlJS.JsonbPopulateRecord.one as any;
+
+/** Returns exactly 1 result. Raises `Exn.t` (with an optionally provided `errorMessage`) if more or less than exactly 1 result is returned. */
+export const JsonbPopulateRecord_expectOne: (_1:PgTyped_Pg_Client_t, _2:jsonbPopulateRecordParams, errorMessage:(undefined | string)) => Promise<jsonbPopulateRecordResult> = Json__sqlJS.JsonbPopulateRecord.expectOne as any;
+
+/** Executes the query, but ignores whatever is returned by it. */
+export const JsonbPopulateRecord_execute: (_1:PgTyped_Pg_Client_t, _2:jsonbPopulateRecordParams) => Promise<void> = Json__sqlJS.JsonbPopulateRecord.execute as any;
+
+/** Returns an array of all matched results. */
+export const JsonbPopulateRecordset_many: (_1:PgTyped_Pg_Client_t, _2:jsonbPopulateRecordsetParams) => Promise<jsonbPopulateRecordsetResult[]> = Json__sqlJS.JsonbPopulateRecordset.many as any;
+
+/** Returns exactly 1 result. Returns `None` if more or less than exactly 1 result is returned. */
+export const JsonbPopulateRecordset_one: (_1:PgTyped_Pg_Client_t, _2:jsonbPopulateRecordsetParams) => Promise<(undefined | jsonbPopulateRecordsetResult)> = Json__sqlJS.JsonbPopulateRecordset.one as any;
+
+/** Returns exactly 1 result. Raises `Exn.t` (with an optionally provided `errorMessage`) if more or less than exactly 1 result is returned. */
+export const JsonbPopulateRecordset_expectOne: (_1:PgTyped_Pg_Client_t, _2:jsonbPopulateRecordsetParams, errorMessage:(undefined | string)) => Promise<jsonbPopulateRecordsetResult> = Json__sqlJS.JsonbPopulateRecordset.expectOne as any;
+
+/** Executes the query, but ignores whatever is returned by it. */
+export const JsonbPopulateRecordset_execute: (_1:PgTyped_Pg_Client_t, _2:jsonbPopulateRecordsetParams) => Promise<void> = Json__sqlJS.JsonbPopulateRecordset.execute as any;
+
+export const JsonExtract: {
+  /** Returns exactly 1 result. Raises `Exn.t` (with an optionally provided `errorMessage`) if more or less than exactly 1 result is returned. */
+  expectOne: (_1:PgTyped_Pg_Client_t, _2:jsonExtractParams, errorMessage:(undefined | string)) => Promise<jsonExtractResult>; 
+  /** Returns exactly 1 result. Returns `None` if more or less than exactly 1 result is returned. */
+  one: (_1:PgTyped_Pg_Client_t, _2:jsonExtractParams) => Promise<(undefined | jsonExtractResult)>; 
+  /** Returns an array of all matched results. */
+  many: (_1:PgTyped_Pg_Client_t, _2:jsonExtractParams) => Promise<jsonExtractResult[]>; 
+  /** Executes the query, but ignores whatever is returned by it. */
+  execute: (_1:PgTyped_Pg_Client_t, _2:jsonExtractParams) => Promise<void>
+} = Json__sqlJS.JsonExtract as any;
+
+export const JsonbPopulateRecord: {
+  /** Returns exactly 1 result. Raises `Exn.t` (with an optionally provided `errorMessage`) if more or less than exactly 1 result is returned. */
+  expectOne: (_1:PgTyped_Pg_Client_t, _2:jsonbPopulateRecordParams, errorMessage:(undefined | string)) => Promise<jsonbPopulateRecordResult>; 
+  /** Returns exactly 1 result. Returns `None` if more or less than exactly 1 result is returned. */
+  one: (_1:PgTyped_Pg_Client_t, _2:jsonbPopulateRecordParams) => Promise<(undefined | jsonbPopulateRecordResult)>; 
+  /** Returns an array of all matched results. */
+  many: (_1:PgTyped_Pg_Client_t, _2:jsonbPopulateRecordParams) => Promise<jsonbPopulateRecordResult[]>; 
+  /** Executes the query, but ignores whatever is returned by it. */
+  execute: (_1:PgTyped_Pg_Client_t, _2:jsonbPopulateRecordParams) => Promise<void>
+} = Json__sqlJS.JsonbPopulateRecord as any;
+
+export const JsonPopulateRecord: {
+  /** Returns exactly 1 result. Raises `Exn.t` (with an optionally provided `errorMessage`) if more or less than exactly 1 result is returned. */
+  expectOne: (_1:PgTyped_Pg_Client_t, _2:jsonPopulateRecordParams, errorMessage:(undefined | string)) => Promise<jsonPopulateRecordResult>; 
+  /** Returns exactly 1 result. Returns `None` if more or less than exactly 1 result is returned. */
+  one: (_1:PgTyped_Pg_Client_t, _2:jsonPopulateRecordParams) => Promise<(undefined | jsonPopulateRecordResult)>; 
+  /** Returns an array of all matched results. */
+  many: (_1:PgTyped_Pg_Client_t, _2:jsonPopulateRecordParams) => Promise<jsonPopulateRecordResult[]>; 
+  /** Executes the query, but ignores whatever is returned by it. */
+  execute: (_1:PgTyped_Pg_Client_t, _2:jsonPopulateRecordParams) => Promise<void>
+} = Json__sqlJS.JsonPopulateRecord as any;
+
 export const JsonPopulateRecordset: {
   /** Returns exactly 1 result. Raises `Exn.t` (with an optionally provided `errorMessage`) if more or less than exactly 1 result is returned. */
   expectOne: (_1:PgTyped_Pg_Client_t, _2:jsonPopulateRecordsetParams, errorMessage:(undefined | string)) => Promise<jsonPopulateRecordsetResult>; 
@@ -106,6 +265,17 @@ export const JsonPopulateRecordset: {
   /** Executes the query, but ignores whatever is returned by it. */
   execute: (_1:PgTyped_Pg_Client_t, _2:jsonPopulateRecordsetParams) => Promise<void>
 } = Json__sqlJS.JsonPopulateRecordset as any;
+
+export const JsonbPopulateRecordset: {
+  /** Returns exactly 1 result. Raises `Exn.t` (with an optionally provided `errorMessage`) if more or less than exactly 1 result is returned. */
+  expectOne: (_1:PgTyped_Pg_Client_t, _2:jsonbPopulateRecordsetParams, errorMessage:(undefined | string)) => Promise<jsonbPopulateRecordsetResult>; 
+  /** Returns exactly 1 result. Returns `None` if more or less than exactly 1 result is returned. */
+  one: (_1:PgTyped_Pg_Client_t, _2:jsonbPopulateRecordsetParams) => Promise<(undefined | jsonbPopulateRecordsetResult)>; 
+  /** Returns an array of all matched results. */
+  many: (_1:PgTyped_Pg_Client_t, _2:jsonbPopulateRecordsetParams) => Promise<jsonbPopulateRecordsetResult[]>; 
+  /** Executes the query, but ignores whatever is returned by it. */
+  execute: (_1:PgTyped_Pg_Client_t, _2:jsonbPopulateRecordsetParams) => Promise<void>
+} = Json__sqlJS.JsonbPopulateRecordset as any;
 
 export const Json: {
   /** Returns exactly 1 result. Raises `Exn.t` (with an optionally provided `errorMessage`) if more or less than exactly 1 result is returned. */

--- a/packages/example/src/books/Json__sql.res
+++ b/packages/example/src/books/Json__sql.res
@@ -2,6 +2,13 @@
 open PgTyped
 
 
+@gentype
+type category = [#"novel" | #"science-fiction" | #"thriller"]
+
+@gentype
+type categoryArray = array<category>
+
+
 /** 'Json' parameters type */
 @gentype
 type jsonParams = unit
@@ -74,8 +81,213 @@ module Json: {
   }
 }
 
+
 @gentype
-@deprecated("Use 'Json.many' directly instead")
-let json = (params, ~client) => Json.many(client, params)
+type jsonPopulateRecordset_booksInputType = {
+  author_id?: int,
+  categories?: categoryArray,
+  id?: int,
+  name?: string,
+  rank?: int,
+}
+
+
+/** 'JsonPopulateRecordset' parameters type */
+@gentype
+type jsonPopulateRecordsetParams = {
+  books: array<jsonPopulateRecordset_booksInputType>,
+}
+
+/** 'JsonPopulateRecordset' return type */
+@gentype
+type jsonPopulateRecordsetResult = {
+  author_id: option<int>,
+  categories: option<categoryArray>,
+  id: int,
+  name: option<string>,
+  rank: option<int>,
+}
+
+/** 'JsonPopulateRecordset' query type */
+@gentype
+type jsonPopulateRecordsetQuery = {
+  params: jsonPopulateRecordsetParams,
+  result: jsonPopulateRecordsetResult,
+}
+
+%%private(let jsonPopulateRecordsetIR: IR.t = %raw(`{"queryName":"JsonPopulateRecordset","inputParamTransforms":{"1":{"type":"stringify"}},"usedParamSet":{"books":true},"params":[{"name":"books","required":true,"transform":{"type":"scalar"},"locs":[{"a":223,"b":229}]}],"statement":"insert into books (\n    name, \n    author_id, \n    categories, \n    rank\n  )\n    select\n      event.name,\n      event.author_id,\n      event.categories,\n      event.rank\n  from json_populate_recordset(\n    null::books,\n    :books!\n  ) as event\n  on conflict (id) do update set \n    name = excluded.name,\n    author_id = excluded.author_id,\n    categories = excluded.categories,\n    rank = excluded.rank\n  returning *"}`))
+
+/**
+ Runnable query:
+ ```sql
+insert into books (
+    name, 
+    author_id, 
+    categories, 
+    rank
+  )
+    select
+      event.name,
+      event.author_id,
+      event.categories,
+      event.rank
+  from json_populate_recordset(
+    null::books,
+    $1
+  ) as event
+  on conflict (id) do update set 
+    name = excluded.name,
+    author_id = excluded.author_id,
+    categories = excluded.categories,
+    rank = excluded.rank
+  returning *
+ ```
+
+ */
+@gentype
+module JsonPopulateRecordset: {
+  /** Returns an array of all matched results. */
+  @gentype
+  let many: (PgTyped.Pg.Client.t, jsonPopulateRecordsetParams) => promise<array<jsonPopulateRecordsetResult>>
+  /** Returns exactly 1 result. Returns `None` if more or less than exactly 1 result is returned. */
+  @gentype
+  let one: (PgTyped.Pg.Client.t, jsonPopulateRecordsetParams) => promise<option<jsonPopulateRecordsetResult>>
+  
+  /** Returns exactly 1 result. Raises `Exn.t` (with an optionally provided `errorMessage`) if more or less than exactly 1 result is returned. */
+  @gentype
+  let expectOne: (
+    PgTyped.Pg.Client.t,
+    jsonPopulateRecordsetParams,
+    ~errorMessage: string=?
+  ) => promise<jsonPopulateRecordsetResult>
+
+  /** Executes the query, but ignores whatever is returned by it. */
+  @gentype
+  let execute: (PgTyped.Pg.Client.t, jsonPopulateRecordsetParams) => promise<unit>
+} = {
+  @module("pgtyped-rescript-runtime") @new external jsonPopulateRecordset: IR.t => PreparedStatement.t<jsonPopulateRecordsetParams, jsonPopulateRecordsetResult> = "PreparedQuery";
+  let query = jsonPopulateRecordset(jsonPopulateRecordsetIR)
+  let query = (params, ~client) => query->PreparedStatement.run(params, ~client)
+
+  @gentype
+  let many = (client, params) => query(params, ~client)
+
+  @gentype
+  let one = async (client, params) => switch await query(params, ~client) {
+  | [item] => Some(item)
+  | _ => None
+  }
+
+  @gentype
+  let expectOne = async (client, params, ~errorMessage=?) => switch await query(params, ~client) {
+  | [item] => item
+  | _ => panic(errorMessage->Option.getOr("More or less than one item was returned"))
+  }
+
+  @gentype
+  let execute = async (client, params) => {
+    let _ = await query(params, ~client)
+  }
+}
+
+
+
+/** 'JsonPopulateRecordsetJsonCast' parameters type */
+@gentype
+type jsonPopulateRecordsetJsonCastParams = {
+  books: JSON.t,
+}
+
+/** 'JsonPopulateRecordsetJsonCast' return type */
+@gentype
+type jsonPopulateRecordsetJsonCastResult = {
+  author_id: option<int>,
+  categories: option<categoryArray>,
+  id: int,
+  name: option<string>,
+  rank: option<int>,
+}
+
+/** 'JsonPopulateRecordsetJsonCast' query type */
+@gentype
+type jsonPopulateRecordsetJsonCastQuery = {
+  params: jsonPopulateRecordsetJsonCastParams,
+  result: jsonPopulateRecordsetJsonCastResult,
+}
+
+%%private(let jsonPopulateRecordsetJsonCastIR: IR.t = %raw(`{"queryName":"JsonPopulateRecordsetJsonCast","usedParamSet":{"books":true},"params":[{"name":"books","required":true,"transform":{"type":"scalar"},"locs":[{"a":223,"b":229}]}],"statement":"insert into books (\n    name, \n    author_id, \n    categories, \n    rank\n  )\n    select\n      event.name,\n      event.author_id,\n      event.categories,\n      event.rank\n  from json_populate_recordset(\n    null::books,\n    :books!::json\n  ) as event\n  on conflict (id) do update set \n    name = excluded.name,\n    author_id = excluded.author_id,\n    categories = excluded.categories,\n    rank = excluded.rank\n  returning *"}`))
+
+/**
+ Runnable query:
+ ```sql
+insert into books (
+    name, 
+    author_id, 
+    categories, 
+    rank
+  )
+    select
+      event.name,
+      event.author_id,
+      event.categories,
+      event.rank
+  from json_populate_recordset(
+    null::books,
+    $1::json
+  ) as event
+  on conflict (id) do update set 
+    name = excluded.name,
+    author_id = excluded.author_id,
+    categories = excluded.categories,
+    rank = excluded.rank
+  returning *
+ ```
+
+ */
+@gentype
+module JsonPopulateRecordsetJsonCast: {
+  /** Returns an array of all matched results. */
+  @gentype
+  let many: (PgTyped.Pg.Client.t, jsonPopulateRecordsetJsonCastParams) => promise<array<jsonPopulateRecordsetJsonCastResult>>
+  /** Returns exactly 1 result. Returns `None` if more or less than exactly 1 result is returned. */
+  @gentype
+  let one: (PgTyped.Pg.Client.t, jsonPopulateRecordsetJsonCastParams) => promise<option<jsonPopulateRecordsetJsonCastResult>>
+  
+  /** Returns exactly 1 result. Raises `Exn.t` (with an optionally provided `errorMessage`) if more or less than exactly 1 result is returned. */
+  @gentype
+  let expectOne: (
+    PgTyped.Pg.Client.t,
+    jsonPopulateRecordsetJsonCastParams,
+    ~errorMessage: string=?
+  ) => promise<jsonPopulateRecordsetJsonCastResult>
+
+  /** Executes the query, but ignores whatever is returned by it. */
+  @gentype
+  let execute: (PgTyped.Pg.Client.t, jsonPopulateRecordsetJsonCastParams) => promise<unit>
+} = {
+  @module("pgtyped-rescript-runtime") @new external jsonPopulateRecordsetJsonCast: IR.t => PreparedStatement.t<jsonPopulateRecordsetJsonCastParams, jsonPopulateRecordsetJsonCastResult> = "PreparedQuery";
+  let query = jsonPopulateRecordsetJsonCast(jsonPopulateRecordsetJsonCastIR)
+  let query = (params, ~client) => query->PreparedStatement.run(params, ~client)
+
+  @gentype
+  let many = (client, params) => query(params, ~client)
+
+  @gentype
+  let one = async (client, params) => switch await query(params, ~client) {
+  | [item] => Some(item)
+  | _ => None
+  }
+
+  @gentype
+  let expectOne = async (client, params, ~errorMessage=?) => switch await query(params, ~client) {
+  | [item] => item
+  | _ => panic(errorMessage->Option.getOr("More or less than one item was returned"))
+  }
+
+  @gentype
+  let execute = async (client, params) => {
+    let _ = await query(params, ~client)
+  }
+}
 
 

--- a/packages/example/src/books/Json__sql.res
+++ b/packages/example/src/books/Json__sql.res
@@ -82,6 +82,86 @@ module Json: {
 }
 
 
+
+/** 'JsonExtract' parameters type */
+@gentype
+type jsonExtractParams = {
+  jsonData: JSON.t,
+}
+
+/** 'JsonExtract' return type */
+@gentype
+type jsonExtractResult = {
+  user_id: option<string>,
+  user_name: option<string>,
+}
+
+/** 'JsonExtract' query type */
+@gentype
+type jsonExtractQuery = {
+  params: jsonExtractParams,
+  result: jsonExtractResult,
+}
+
+%%private(let jsonExtractIR: IR.t = %raw(`{"queryName":"JsonExtract","inputParamTransforms":{"1":{"type":"stringify"}},"usedParamSet":{"jsonData":true},"params":[{"name":"jsonData","required":true,"transform":{"type":"scalar"},"locs":[{"a":96,"b":105}]}],"statement":"SELECT \n    value->>'name' AS user_name,\n    value->>'id' AS user_id\n  FROM json_array_elements(:jsonData!::json) AS value"}`))
+
+/**
+ Runnable query:
+ ```sql
+SELECT 
+    value->>'name' AS user_name,
+    value->>'id' AS user_id
+  FROM json_array_elements($1::json) AS value
+ ```
+
+ */
+@gentype
+module JsonExtract: {
+  /** Returns an array of all matched results. */
+  @gentype
+  let many: (PgTyped.Pg.Client.t, jsonExtractParams) => promise<array<jsonExtractResult>>
+  /** Returns exactly 1 result. Returns `None` if more or less than exactly 1 result is returned. */
+  @gentype
+  let one: (PgTyped.Pg.Client.t, jsonExtractParams) => promise<option<jsonExtractResult>>
+  
+  /** Returns exactly 1 result. Raises `Exn.t` (with an optionally provided `errorMessage`) if more or less than exactly 1 result is returned. */
+  @gentype
+  let expectOne: (
+    PgTyped.Pg.Client.t,
+    jsonExtractParams,
+    ~errorMessage: string=?
+  ) => promise<jsonExtractResult>
+
+  /** Executes the query, but ignores whatever is returned by it. */
+  @gentype
+  let execute: (PgTyped.Pg.Client.t, jsonExtractParams) => promise<unit>
+} = {
+  @module("pgtyped-rescript-runtime") @new external jsonExtract: IR.t => PreparedStatement.t<jsonExtractParams, jsonExtractResult> = "PreparedQuery";
+  let query = jsonExtract(jsonExtractIR)
+  let query = (params, ~client) => query->PreparedStatement.run(params, ~client)
+
+  @gentype
+  let many = (client, params) => query(params, ~client)
+
+  @gentype
+  let one = async (client, params) => switch await query(params, ~client) {
+  | [item] => Some(item)
+  | _ => None
+  }
+
+  @gentype
+  let expectOne = async (client, params, ~errorMessage=?) => switch await query(params, ~client) {
+  | [item] => item
+  | _ => panic(errorMessage->Option.getOr("More or less than one item was returned"))
+  }
+
+  @gentype
+  let execute = async (client, params) => {
+    let _ = await query(params, ~client)
+  }
+}
+
+
 @gentype
 type jsonPopulateRecord_booksInputType = {
   author_id?: int,
@@ -307,7 +387,7 @@ type jsonPopulateRecordsetJsonCastQuery = {
   result: jsonPopulateRecordsetJsonCastResult,
 }
 
-%%private(let jsonPopulateRecordsetJsonCastIR: IR.t = %raw(`{"queryName":"JsonPopulateRecordsetJsonCast","usedParamSet":{"books":true},"params":[{"name":"books","required":true,"transform":{"type":"scalar"},"locs":[{"a":223,"b":229}]}],"statement":"insert into books (\n    name, \n    author_id, \n    categories, \n    rank\n  )\n    select\n      event.name,\n      event.author_id,\n      event.categories,\n      event.rank\n  from json_populate_recordset(\n    null::books,\n    :books!::json\n  ) as event\n  on conflict (id) do update set \n    name = excluded.name,\n    author_id = excluded.author_id,\n    categories = excluded.categories,\n    rank = excluded.rank\n  returning *"}`))
+%%private(let jsonPopulateRecordsetJsonCastIR: IR.t = %raw(`{"queryName":"JsonPopulateRecordsetJsonCast","inputParamTransforms":{"1":{"type":"stringify"}},"usedParamSet":{"books":true},"params":[{"name":"books","required":true,"transform":{"type":"scalar"},"locs":[{"a":223,"b":229}]}],"statement":"insert into books (\n    name, \n    author_id, \n    categories, \n    rank\n  )\n    select\n      event.name,\n      event.author_id,\n      event.categories,\n      event.rank\n  from json_populate_recordset(\n    null::books,\n    :books!::json\n  ) as event\n  on conflict (id) do update set \n    name = excluded.name,\n    author_id = excluded.author_id,\n    categories = excluded.categories,\n    rank = excluded.rank\n  returning *"}`))
 
 /**
  Runnable query:

--- a/packages/example/src/books/Json__sql.res
+++ b/packages/example/src/books/Json__sql.res
@@ -83,6 +83,98 @@ module Json: {
 
 
 @gentype
+type jsonPopulateRecord_booksInputType = {
+  author_id?: int,
+  categories?: categoryArray,
+  id?: int,
+  name?: string,
+  rank?: int,
+}
+
+
+/** 'JsonPopulateRecord' parameters type */
+@gentype
+type jsonPopulateRecordParams = {
+  book: jsonPopulateRecord_booksInputType,
+}
+
+/** 'JsonPopulateRecord' return type */
+@gentype
+type jsonPopulateRecordResult = {
+  author_id: option<int>,
+  categories: option<categoryArray>,
+  id: option<int>,
+  name: option<string>,
+  rank: option<int>,
+}
+
+/** 'JsonPopulateRecord' query type */
+@gentype
+type jsonPopulateRecordQuery = {
+  params: jsonPopulateRecordParams,
+  result: jsonPopulateRecordResult,
+}
+
+%%private(let jsonPopulateRecordIR: IR.t = %raw(`{"queryName":"JsonPopulateRecord","inputParamTransforms":{"1":{"type":"stringify"}},"usedParamSet":{"book":true},"params":[{"name":"book","required":true,"transform":{"type":"scalar"},"locs":[{"a":57,"b":62}]}],"statement":"SELECT * FROM json_populate_record(\n    null::books,\n    :book!\n  )"}`))
+
+/**
+ Runnable query:
+ ```sql
+SELECT * FROM json_populate_record(
+    null::books,
+    $1
+  )
+ ```
+
+ */
+@gentype
+module JsonPopulateRecord: {
+  /** Returns an array of all matched results. */
+  @gentype
+  let many: (PgTyped.Pg.Client.t, jsonPopulateRecordParams) => promise<array<jsonPopulateRecordResult>>
+  /** Returns exactly 1 result. Returns `None` if more or less than exactly 1 result is returned. */
+  @gentype
+  let one: (PgTyped.Pg.Client.t, jsonPopulateRecordParams) => promise<option<jsonPopulateRecordResult>>
+  
+  /** Returns exactly 1 result. Raises `Exn.t` (with an optionally provided `errorMessage`) if more or less than exactly 1 result is returned. */
+  @gentype
+  let expectOne: (
+    PgTyped.Pg.Client.t,
+    jsonPopulateRecordParams,
+    ~errorMessage: string=?
+  ) => promise<jsonPopulateRecordResult>
+
+  /** Executes the query, but ignores whatever is returned by it. */
+  @gentype
+  let execute: (PgTyped.Pg.Client.t, jsonPopulateRecordParams) => promise<unit>
+} = {
+  @module("pgtyped-rescript-runtime") @new external jsonPopulateRecord: IR.t => PreparedStatement.t<jsonPopulateRecordParams, jsonPopulateRecordResult> = "PreparedQuery";
+  let query = jsonPopulateRecord(jsonPopulateRecordIR)
+  let query = (params, ~client) => query->PreparedStatement.run(params, ~client)
+
+  @gentype
+  let many = (client, params) => query(params, ~client)
+
+  @gentype
+  let one = async (client, params) => switch await query(params, ~client) {
+  | [item] => Some(item)
+  | _ => None
+  }
+
+  @gentype
+  let expectOne = async (client, params, ~errorMessage=?) => switch await query(params, ~client) {
+  | [item] => item
+  | _ => panic(errorMessage->Option.getOr("More or less than one item was returned"))
+  }
+
+  @gentype
+  let execute = async (client, params) => {
+    let _ = await query(params, ~client)
+  }
+}
+
+
+@gentype
 type jsonPopulateRecordset_booksInputType = {
   author_id?: int,
   categories?: categoryArray,
@@ -267,6 +359,190 @@ module JsonPopulateRecordsetJsonCast: {
 } = {
   @module("pgtyped-rescript-runtime") @new external jsonPopulateRecordsetJsonCast: IR.t => PreparedStatement.t<jsonPopulateRecordsetJsonCastParams, jsonPopulateRecordsetJsonCastResult> = "PreparedQuery";
   let query = jsonPopulateRecordsetJsonCast(jsonPopulateRecordsetJsonCastIR)
+  let query = (params, ~client) => query->PreparedStatement.run(params, ~client)
+
+  @gentype
+  let many = (client, params) => query(params, ~client)
+
+  @gentype
+  let one = async (client, params) => switch await query(params, ~client) {
+  | [item] => Some(item)
+  | _ => None
+  }
+
+  @gentype
+  let expectOne = async (client, params, ~errorMessage=?) => switch await query(params, ~client) {
+  | [item] => item
+  | _ => panic(errorMessage->Option.getOr("More or less than one item was returned"))
+  }
+
+  @gentype
+  let execute = async (client, params) => {
+    let _ = await query(params, ~client)
+  }
+}
+
+
+@gentype
+type jsonbPopulateRecord_booksInputType = {
+  author_id?: int,
+  categories?: categoryArray,
+  id?: int,
+  name?: string,
+  rank?: int,
+}
+
+
+/** 'JsonbPopulateRecord' parameters type */
+@gentype
+type jsonbPopulateRecordParams = {
+  book: jsonbPopulateRecord_booksInputType,
+}
+
+/** 'JsonbPopulateRecord' return type */
+@gentype
+type jsonbPopulateRecordResult = {
+  author_id: option<int>,
+  categories: option<categoryArray>,
+  id: option<int>,
+  name: option<string>,
+  rank: option<int>,
+}
+
+/** 'JsonbPopulateRecord' query type */
+@gentype
+type jsonbPopulateRecordQuery = {
+  params: jsonbPopulateRecordParams,
+  result: jsonbPopulateRecordResult,
+}
+
+%%private(let jsonbPopulateRecordIR: IR.t = %raw(`{"queryName":"JsonbPopulateRecord","inputParamTransforms":{"1":{"type":"stringify"}},"usedParamSet":{"book":true},"params":[{"name":"book","required":true,"transform":{"type":"scalar"},"locs":[{"a":58,"b":63}]}],"statement":"SELECT * FROM jsonb_populate_record(\n    null::books,\n    :book!\n  )"}`))
+
+/**
+ Runnable query:
+ ```sql
+SELECT * FROM jsonb_populate_record(
+    null::books,
+    $1
+  )
+ ```
+
+ */
+@gentype
+module JsonbPopulateRecord: {
+  /** Returns an array of all matched results. */
+  @gentype
+  let many: (PgTyped.Pg.Client.t, jsonbPopulateRecordParams) => promise<array<jsonbPopulateRecordResult>>
+  /** Returns exactly 1 result. Returns `None` if more or less than exactly 1 result is returned. */
+  @gentype
+  let one: (PgTyped.Pg.Client.t, jsonbPopulateRecordParams) => promise<option<jsonbPopulateRecordResult>>
+  
+  /** Returns exactly 1 result. Raises `Exn.t` (with an optionally provided `errorMessage`) if more or less than exactly 1 result is returned. */
+  @gentype
+  let expectOne: (
+    PgTyped.Pg.Client.t,
+    jsonbPopulateRecordParams,
+    ~errorMessage: string=?
+  ) => promise<jsonbPopulateRecordResult>
+
+  /** Executes the query, but ignores whatever is returned by it. */
+  @gentype
+  let execute: (PgTyped.Pg.Client.t, jsonbPopulateRecordParams) => promise<unit>
+} = {
+  @module("pgtyped-rescript-runtime") @new external jsonbPopulateRecord: IR.t => PreparedStatement.t<jsonbPopulateRecordParams, jsonbPopulateRecordResult> = "PreparedQuery";
+  let query = jsonbPopulateRecord(jsonbPopulateRecordIR)
+  let query = (params, ~client) => query->PreparedStatement.run(params, ~client)
+
+  @gentype
+  let many = (client, params) => query(params, ~client)
+
+  @gentype
+  let one = async (client, params) => switch await query(params, ~client) {
+  | [item] => Some(item)
+  | _ => None
+  }
+
+  @gentype
+  let expectOne = async (client, params, ~errorMessage=?) => switch await query(params, ~client) {
+  | [item] => item
+  | _ => panic(errorMessage->Option.getOr("More or less than one item was returned"))
+  }
+
+  @gentype
+  let execute = async (client, params) => {
+    let _ = await query(params, ~client)
+  }
+}
+
+
+@gentype
+type jsonbPopulateRecordset_booksInputType = {
+  author_id?: int,
+  categories?: categoryArray,
+  id?: int,
+  name?: string,
+  rank?: int,
+}
+
+
+/** 'JsonbPopulateRecordset' parameters type */
+@gentype
+type jsonbPopulateRecordsetParams = {
+  books: array<jsonbPopulateRecordset_booksInputType>,
+}
+
+/** 'JsonbPopulateRecordset' return type */
+@gentype
+type jsonbPopulateRecordsetResult = {
+  author_id: option<int>,
+  categories: option<categoryArray>,
+  id: option<int>,
+  name: option<string>,
+  rank: option<int>,
+}
+
+/** 'JsonbPopulateRecordset' query type */
+@gentype
+type jsonbPopulateRecordsetQuery = {
+  params: jsonbPopulateRecordsetParams,
+  result: jsonbPopulateRecordsetResult,
+}
+
+%%private(let jsonbPopulateRecordsetIR: IR.t = %raw(`{"queryName":"JsonbPopulateRecordset","inputParamTransforms":{"1":{"type":"stringify"}},"usedParamSet":{"books":true},"params":[{"name":"books","required":true,"transform":{"type":"scalar"},"locs":[{"a":61,"b":67}]}],"statement":"SELECT * FROM jsonb_populate_recordset(\n    null::books,\n    :books!\n  )"}`))
+
+/**
+ Runnable query:
+ ```sql
+SELECT * FROM jsonb_populate_recordset(
+    null::books,
+    $1
+  )
+ ```
+
+ */
+@gentype
+module JsonbPopulateRecordset: {
+  /** Returns an array of all matched results. */
+  @gentype
+  let many: (PgTyped.Pg.Client.t, jsonbPopulateRecordsetParams) => promise<array<jsonbPopulateRecordsetResult>>
+  /** Returns exactly 1 result. Returns `None` if more or less than exactly 1 result is returned. */
+  @gentype
+  let one: (PgTyped.Pg.Client.t, jsonbPopulateRecordsetParams) => promise<option<jsonbPopulateRecordsetResult>>
+  
+  /** Returns exactly 1 result. Raises `Exn.t` (with an optionally provided `errorMessage`) if more or less than exactly 1 result is returned. */
+  @gentype
+  let expectOne: (
+    PgTyped.Pg.Client.t,
+    jsonbPopulateRecordsetParams,
+    ~errorMessage: string=?
+  ) => promise<jsonbPopulateRecordsetResult>
+
+  /** Executes the query, but ignores whatever is returned by it. */
+  @gentype
+  let execute: (PgTyped.Pg.Client.t, jsonbPopulateRecordsetParams) => promise<unit>
+} = {
+  @module("pgtyped-rescript-runtime") @new external jsonbPopulateRecordset: IR.t => PreparedStatement.t<jsonbPopulateRecordsetParams, jsonbPopulateRecordsetResult> = "PreparedQuery";
+  let query = jsonbPopulateRecordset(jsonbPopulateRecordsetIR)
   let query = (params, ~client) => query->PreparedStatement.run(params, ~client)
 
   @gentype

--- a/packages/example/src/books/Json__sql.res
+++ b/packages/example/src/books/Json__sql.res
@@ -6,6 +6,9 @@ open PgTyped
 type category = [#"novel" | #"science-fiction" | #"thriller"]
 
 @gentype
+type arrayJSON_t = array<JSON.t>
+
+@gentype
 type categoryArray = array<category>
 
 
@@ -138,6 +141,82 @@ module JsonExtract: {
 } = {
   @module("pgtyped-rescript-runtime") @new external jsonExtract: IR.t => PreparedStatement.t<jsonExtractParams, jsonExtractResult> = "PreparedQuery";
   let query = jsonExtract(jsonExtractIR)
+  let query = (params, ~client) => query->PreparedStatement.run(params, ~client)
+
+  @gentype
+  let many = (client, params) => query(params, ~client)
+
+  @gentype
+  let one = async (client, params) => switch await query(params, ~client) {
+  | [item] => Some(item)
+  | _ => None
+  }
+
+  @gentype
+  let expectOne = async (client, params, ~errorMessage=?) => switch await query(params, ~client) {
+  | [item] => item
+  | _ => panic(errorMessage->Option.getOr("More or less than one item was returned"))
+  }
+
+  @gentype
+  let execute = async (client, params) => {
+    let _ = await query(params, ~client)
+  }
+}
+
+
+
+/** 'JsonUnnestCast' parameters type */
+@gentype
+type jsonUnnestCastParams = {
+  jsonData: arrayJSON_t,
+}
+
+/** 'JsonUnnestCast' return type */
+@gentype
+type jsonUnnestCastResult = {
+  json_arr: option<JSON.t>,
+}
+
+/** 'JsonUnnestCast' query type */
+@gentype
+type jsonUnnestCastQuery = {
+  params: jsonUnnestCastParams,
+  result: jsonUnnestCastResult,
+}
+
+%%private(let jsonUnnestCastIR: IR.t = %raw(`{"queryName":"JsonUnnestCast","inputParamTransforms":{"1":{"type":"stringify"}},"usedParamSet":{"jsonData":true},"params":[{"name":"jsonData","required":true,"transform":{"type":"scalar"},"locs":[{"a":14,"b":23}]}],"statement":"SELECT unnest(:jsonData!::json[]) AS json_arr"}`))
+
+/**
+ Runnable query:
+ ```sql
+SELECT unnest($1::json[]) AS json_arr
+ ```
+
+ */
+@gentype
+module JsonUnnestCast: {
+  /** Returns an array of all matched results. */
+  @gentype
+  let many: (PgTyped.Pg.Client.t, jsonUnnestCastParams) => promise<array<jsonUnnestCastResult>>
+  /** Returns exactly 1 result. Returns `None` if more or less than exactly 1 result is returned. */
+  @gentype
+  let one: (PgTyped.Pg.Client.t, jsonUnnestCastParams) => promise<option<jsonUnnestCastResult>>
+  
+  /** Returns exactly 1 result. Raises `Exn.t` (with an optionally provided `errorMessage`) if more or less than exactly 1 result is returned. */
+  @gentype
+  let expectOne: (
+    PgTyped.Pg.Client.t,
+    jsonUnnestCastParams,
+    ~errorMessage: string=?
+  ) => promise<jsonUnnestCastResult>
+
+  /** Executes the query, but ignores whatever is returned by it. */
+  @gentype
+  let execute: (PgTyped.Pg.Client.t, jsonUnnestCastParams) => promise<unit>
+} = {
+  @module("pgtyped-rescript-runtime") @new external jsonUnnestCast: IR.t => PreparedStatement.t<jsonUnnestCastParams, jsonUnnestCastResult> = "PreparedQuery";
+  let query = jsonUnnestCast(jsonUnnestCastIR)
   let query = (params, ~client) => query->PreparedStatement.run(params, ~client)
 
   @gentype

--- a/packages/example/src/books/Keywords__sql.gen.tsx
+++ b/packages/example/src/books/Keywords__sql.gen.tsx
@@ -47,8 +47,6 @@ export const Keywords_expectOne: (_1:PgTyped_Pg_Client_t, _2:keywordsParams, err
 /** Executes the query, but ignores whatever is returned by it. */
 export const Keywords_execute: (_1:PgTyped_Pg_Client_t, _2:keywordsParams) => Promise<void> = Keywords__sqlJS.Keywords.execute as any;
 
-export const keywords: (params:keywordsParams, client:PgTyped_Pg_Client_t) => Promise<keywordsResult[]> = Keywords__sqlJS.keywords as any;
-
 export const Keywords: {
   /** Returns exactly 1 result. Raises `Exn.t` (with an optionally provided `errorMessage`) if more or less than exactly 1 result is returned. */
   expectOne: (_1:PgTyped_Pg_Client_t, _2:keywordsParams, errorMessage:(undefined | string)) => Promise<keywordsResult>; 

--- a/packages/example/src/books/Keywords__sql.res
+++ b/packages/example/src/books/Keywords__sql.res
@@ -2,6 +2,7 @@
 open PgTyped
 
 
+
 /** 'Keywords' parameters type */
 @gentype
 type keywordsParams = unit
@@ -90,9 +91,5 @@ module Keywords: {
     let _ = await query(params, ~client)
   }
 }
-
-@gentype
-@deprecated("Use 'Keywords.many' directly instead")
-let keywords = (params, ~client) => Keywords.many(client, params)
 
 

--- a/packages/example/src/books/Misc__sql.gen.tsx
+++ b/packages/example/src/books/Misc__sql.gen.tsx
@@ -151,8 +151,6 @@ export const Literals_expectOne: (_1:PgTyped_Pg_Client_t, _2:literalsParams, err
 /** Executes the query, but ignores whatever is returned by it. */
 export const Literals_execute: (_1:PgTyped_Pg_Client_t, _2:literalsParams) => Promise<void> = Misc__sqlJS.Literals.execute as any;
 
-export const literals: (params:literalsParams, client:PgTyped_Pg_Client_t) => Promise<literalsResult[]> = Misc__sqlJS.literals as any;
-
 /** Returns an array of all matched results. */
 export const MoreLiterals_many: (_1:PgTyped_Pg_Client_t, _2:moreLiteralsParams) => Promise<moreLiteralsResult[]> = Misc__sqlJS.MoreLiterals.many as any;
 
@@ -164,8 +162,6 @@ export const MoreLiterals_expectOne: (_1:PgTyped_Pg_Client_t, _2:moreLiteralsPar
 
 /** Executes the query, but ignores whatever is returned by it. */
 export const MoreLiterals_execute: (_1:PgTyped_Pg_Client_t, _2:moreLiteralsParams) => Promise<void> = Misc__sqlJS.MoreLiterals.execute as any;
-
-export const moreLiterals: (params:moreLiteralsParams, client:PgTyped_Pg_Client_t) => Promise<moreLiteralsResult[]> = Misc__sqlJS.moreLiterals as any;
 
 /** Returns an array of all matched results. */
 export const DuplicateAliasTest_many: (_1:PgTyped_Pg_Client_t, _2:duplicateAliasTestParams) => Promise<duplicateAliasTestResult[]> = Misc__sqlJS.DuplicateAliasTest.many as any;
@@ -179,8 +175,6 @@ export const DuplicateAliasTest_expectOne: (_1:PgTyped_Pg_Client_t, _2:duplicate
 /** Executes the query, but ignores whatever is returned by it. */
 export const DuplicateAliasTest_execute: (_1:PgTyped_Pg_Client_t, _2:duplicateAliasTestParams) => Promise<void> = Misc__sqlJS.DuplicateAliasTest.execute as any;
 
-export const duplicateAliasTest: (params:duplicateAliasTestParams, client:PgTyped_Pg_Client_t) => Promise<duplicateAliasTestResult[]> = Misc__sqlJS.duplicateAliasTest as any;
-
 /** Returns an array of all matched results. */
 export const UnionTest_many: (_1:PgTyped_Pg_Client_t, _2:unionTestParams) => Promise<unionTestResult[]> = Misc__sqlJS.UnionTest.many as any;
 
@@ -192,8 +186,6 @@ export const UnionTest_expectOne: (_1:PgTyped_Pg_Client_t, _2:unionTestParams, e
 
 /** Executes the query, but ignores whatever is returned by it. */
 export const UnionTest_execute: (_1:PgTyped_Pg_Client_t, _2:unionTestParams) => Promise<void> = Misc__sqlJS.UnionTest.execute as any;
-
-export const unionTest: (params:unionTestParams, client:PgTyped_Pg_Client_t) => Promise<unionTestResult[]> = Misc__sqlJS.unionTest as any;
 
 /** Returns an array of all matched results. */
 export const UnionTestWithString_many: (_1:PgTyped_Pg_Client_t, _2:unionTestWithStringParams) => Promise<unionTestWithStringResult[]> = Misc__sqlJS.UnionTestWithString.many as any;
@@ -207,8 +199,6 @@ export const UnionTestWithString_expectOne: (_1:PgTyped_Pg_Client_t, _2:unionTes
 /** Executes the query, but ignores whatever is returned by it. */
 export const UnionTestWithString_execute: (_1:PgTyped_Pg_Client_t, _2:unionTestWithStringParams) => Promise<void> = Misc__sqlJS.UnionTestWithString.execute as any;
 
-export const unionTestWithString: (params:unionTestWithStringParams, client:PgTyped_Pg_Client_t) => Promise<unionTestWithStringResult[]> = Misc__sqlJS.unionTestWithString as any;
-
 /** Returns an array of all matched results. */
 export const SingleLiterals_many: (_1:PgTyped_Pg_Client_t, _2:singleLiteralsParams) => Promise<singleLiteralsResult[]> = Misc__sqlJS.SingleLiterals.many as any;
 
@@ -220,8 +210,6 @@ export const SingleLiterals_expectOne: (_1:PgTyped_Pg_Client_t, _2:singleLiteral
 
 /** Executes the query, but ignores whatever is returned by it. */
 export const SingleLiterals_execute: (_1:PgTyped_Pg_Client_t, _2:singleLiteralsParams) => Promise<void> = Misc__sqlJS.SingleLiterals.execute as any;
-
-export const singleLiterals: (params:singleLiteralsParams, client:PgTyped_Pg_Client_t) => Promise<singleLiteralsResult[]> = Misc__sqlJS.singleLiterals as any;
 
 /** Returns an array of all matched results. */
 export const EdgeCases_many: (_1:PgTyped_Pg_Client_t, _2:edgeCasesParams) => Promise<edgeCasesResult[]> = Misc__sqlJS.EdgeCases.many as any;
@@ -235,8 +223,6 @@ export const EdgeCases_expectOne: (_1:PgTyped_Pg_Client_t, _2:edgeCasesParams, e
 /** Executes the query, but ignores whatever is returned by it. */
 export const EdgeCases_execute: (_1:PgTyped_Pg_Client_t, _2:edgeCasesParams) => Promise<void> = Misc__sqlJS.EdgeCases.execute as any;
 
-export const edgeCases: (params:edgeCasesParams, client:PgTyped_Pg_Client_t) => Promise<edgeCasesResult[]> = Misc__sqlJS.edgeCases as any;
-
 /** Returns an array of all matched results. */
 export const ContextTest_many: (_1:PgTyped_Pg_Client_t, _2:contextTestParams) => Promise<contextTestResult[]> = Misc__sqlJS.ContextTest.many as any;
 
@@ -248,8 +234,6 @@ export const ContextTest_expectOne: (_1:PgTyped_Pg_Client_t, _2:contextTestParam
 
 /** Executes the query, but ignores whatever is returned by it. */
 export const ContextTest_execute: (_1:PgTyped_Pg_Client_t, _2:contextTestParams) => Promise<void> = Misc__sqlJS.ContextTest.execute as any;
-
-export const contextTest: (params:contextTestParams, client:PgTyped_Pg_Client_t) => Promise<contextTestResult[]> = Misc__sqlJS.contextTest as any;
 
 export const MoreLiterals: {
   /** Returns exactly 1 result. Raises `Exn.t` (with an optionally provided `errorMessage`) if more or less than exactly 1 result is returned. */

--- a/packages/example/src/books/Misc__sql.res
+++ b/packages/example/src/books/Misc__sql.res
@@ -2,6 +2,7 @@
 open PgTyped
 
 
+
 /** 'Literals' parameters type */
 @gentype
 type literalsParams = unit
@@ -79,9 +80,6 @@ module Literals: {
   }
 }
 
-@gentype
-@deprecated("Use 'Literals.many' directly instead")
-let literals = (params, ~client) => Literals.many(client, params)
 
 
 /** 'MoreLiterals' parameters type */
@@ -175,9 +173,6 @@ module MoreLiterals: {
   }
 }
 
-@gentype
-@deprecated("Use 'MoreLiterals.many' directly instead")
-let moreLiterals = (params, ~client) => MoreLiterals.many(client, params)
 
 
 /** 'DuplicateAliasTest' parameters type */
@@ -257,9 +252,6 @@ module DuplicateAliasTest: {
   }
 }
 
-@gentype
-@deprecated("Use 'DuplicateAliasTest.many' directly instead")
-let duplicateAliasTest = (params, ~client) => DuplicateAliasTest.many(client, params)
 
 
 /** 'UnionTest' parameters type */
@@ -337,9 +329,6 @@ module UnionTest: {
   }
 }
 
-@gentype
-@deprecated("Use 'UnionTest.many' directly instead")
-let unionTest = (params, ~client) => UnionTest.many(client, params)
 
 
 /** 'UnionTestWithString' parameters type */
@@ -419,9 +408,6 @@ module UnionTestWithString: {
   }
 }
 
-@gentype
-@deprecated("Use 'UnionTestWithString.many' directly instead")
-let unionTestWithString = (params, ~client) => UnionTestWithString.many(client, params)
 
 
 /** 'SingleLiterals' parameters type */
@@ -501,9 +487,6 @@ module SingleLiterals: {
   }
 }
 
-@gentype
-@deprecated("Use 'SingleLiterals.many' directly instead")
-let singleLiterals = (params, ~client) => SingleLiterals.many(client, params)
 
 
 /** 'EdgeCases' parameters type */
@@ -593,9 +576,6 @@ module EdgeCases: {
   }
 }
 
-@gentype
-@deprecated("Use 'EdgeCases.many' directly instead")
-let edgeCases = (params, ~client) => EdgeCases.many(client, params)
 
 
 /** 'ContextTest' parameters type */
@@ -682,9 +662,5 @@ module ContextTest: {
     let _ = await query(params, ~client)
   }
 }
-
-@gentype
-@deprecated("Use 'ContextTest.many' directly instead")
-let contextTest = (params, ~client) => ContextTest.many(client, params)
 
 

--- a/packages/example/src/books/books__sql.gen.tsx
+++ b/packages/example/src/books/books__sql.gen.tsx
@@ -421,8 +421,6 @@ export const FindBookById_expectOne: (_1:PgTyped_Pg_Client_t, _2:findBookByIdPar
 /** Executes the query, but ignores whatever is returned by it. */
 export const FindBookById_execute: (_1:PgTyped_Pg_Client_t, _2:findBookByIdParams) => Promise<void> = books__sqlJS.FindBookById.execute as any;
 
-export const findBookById: (params:findBookByIdParams, client:PgTyped_Pg_Client_t) => Promise<findBookByIdResult[]> = books__sqlJS.findBookById as any;
-
 /** Returns an array of all matched results. */
 export const FindBookByCategory_many: (_1:PgTyped_Pg_Client_t, _2:findBookByCategoryParams) => Promise<findBookByCategoryResult[]> = books__sqlJS.FindBookByCategory.many as any;
 
@@ -434,8 +432,6 @@ export const FindBookByCategory_expectOne: (_1:PgTyped_Pg_Client_t, _2:findBookB
 
 /** Executes the query, but ignores whatever is returned by it. */
 export const FindBookByCategory_execute: (_1:PgTyped_Pg_Client_t, _2:findBookByCategoryParams) => Promise<void> = books__sqlJS.FindBookByCategory.execute as any;
-
-export const findBookByCategory: (params:findBookByCategoryParams, client:PgTyped_Pg_Client_t) => Promise<findBookByCategoryResult[]> = books__sqlJS.findBookByCategory as any;
 
 /** Returns an array of all matched results. */
 export const FindBookNameOrRank_many: (_1:PgTyped_Pg_Client_t, _2:findBookNameOrRankParams) => Promise<findBookNameOrRankResult[]> = books__sqlJS.FindBookNameOrRank.many as any;
@@ -449,8 +445,6 @@ export const FindBookNameOrRank_expectOne: (_1:PgTyped_Pg_Client_t, _2:findBookN
 /** Executes the query, but ignores whatever is returned by it. */
 export const FindBookNameOrRank_execute: (_1:PgTyped_Pg_Client_t, _2:findBookNameOrRankParams) => Promise<void> = books__sqlJS.FindBookNameOrRank.execute as any;
 
-export const findBookNameOrRank: (params:findBookNameOrRankParams, client:PgTyped_Pg_Client_t) => Promise<findBookNameOrRankResult[]> = books__sqlJS.findBookNameOrRank as any;
-
 /** Returns an array of all matched results. */
 export const FindBookUnicode_many: (_1:PgTyped_Pg_Client_t, _2:findBookUnicodeParams) => Promise<findBookUnicodeResult[]> = books__sqlJS.FindBookUnicode.many as any;
 
@@ -462,8 +456,6 @@ export const FindBookUnicode_expectOne: (_1:PgTyped_Pg_Client_t, _2:findBookUnic
 
 /** Executes the query, but ignores whatever is returned by it. */
 export const FindBookUnicode_execute: (_1:PgTyped_Pg_Client_t, _2:findBookUnicodeParams) => Promise<void> = books__sqlJS.FindBookUnicode.execute as any;
-
-export const findBookUnicode: (params:findBookUnicodeParams, client:PgTyped_Pg_Client_t) => Promise<findBookUnicodeResult[]> = books__sqlJS.findBookUnicode as any;
 
 /** Returns an array of all matched results. */
 export const InsertBooks_many: (_1:PgTyped_Pg_Client_t, _2:insertBooksParams) => Promise<insertBooksResult[]> = books__sqlJS.InsertBooks.many as any;
@@ -477,8 +469,6 @@ export const InsertBooks_expectOne: (_1:PgTyped_Pg_Client_t, _2:insertBooksParam
 /** Executes the query, but ignores whatever is returned by it. */
 export const InsertBooks_execute: (_1:PgTyped_Pg_Client_t, _2:insertBooksParams) => Promise<void> = books__sqlJS.InsertBooks.execute as any;
 
-export const insertBooks: (params:insertBooksParams, client:PgTyped_Pg_Client_t) => Promise<insertBooksResult[]> = books__sqlJS.insertBooks as any;
-
 /** Returns an array of all matched results. */
 export const InsertBook_many: (_1:PgTyped_Pg_Client_t, _2:insertBookParams) => Promise<insertBookResult[]> = books__sqlJS.InsertBook.many as any;
 
@@ -490,8 +480,6 @@ export const InsertBook_expectOne: (_1:PgTyped_Pg_Client_t, _2:insertBookParams,
 
 /** Executes the query, but ignores whatever is returned by it. */
 export const InsertBook_execute: (_1:PgTyped_Pg_Client_t, _2:insertBookParams) => Promise<void> = books__sqlJS.InsertBook.execute as any;
-
-export const insertBook: (params:insertBookParams, client:PgTyped_Pg_Client_t) => Promise<insertBookResult[]> = books__sqlJS.insertBook as any;
 
 /** Returns an array of all matched results. */
 export const UpdateBooksCustom_many: (_1:PgTyped_Pg_Client_t, _2:updateBooksCustomParams) => Promise<updateBooksCustomResult[]> = books__sqlJS.UpdateBooksCustom.many as any;
@@ -505,8 +493,6 @@ export const UpdateBooksCustom_expectOne: (_1:PgTyped_Pg_Client_t, _2:updateBook
 /** Executes the query, but ignores whatever is returned by it. */
 export const UpdateBooksCustom_execute: (_1:PgTyped_Pg_Client_t, _2:updateBooksCustomParams) => Promise<void> = books__sqlJS.UpdateBooksCustom.execute as any;
 
-export const updateBooksCustom: (params:updateBooksCustomParams, client:PgTyped_Pg_Client_t) => Promise<updateBooksCustomResult[]> = books__sqlJS.updateBooksCustom as any;
-
 /** Returns an array of all matched results. */
 export const UpdateBooks_many: (_1:PgTyped_Pg_Client_t, _2:updateBooksParams) => Promise<updateBooksResult[]> = books__sqlJS.UpdateBooks.many as any;
 
@@ -518,8 +504,6 @@ export const UpdateBooks_expectOne: (_1:PgTyped_Pg_Client_t, _2:updateBooksParam
 
 /** Executes the query, but ignores whatever is returned by it. */
 export const UpdateBooks_execute: (_1:PgTyped_Pg_Client_t, _2:updateBooksParams) => Promise<void> = books__sqlJS.UpdateBooks.execute as any;
-
-export const updateBooks: (params:updateBooksParams, client:PgTyped_Pg_Client_t) => Promise<updateBooksResult[]> = books__sqlJS.updateBooks as any;
 
 /** Returns an array of all matched results. */
 export const UpdateBooksRankNotNull_many: (_1:PgTyped_Pg_Client_t, _2:updateBooksRankNotNullParams) => Promise<updateBooksRankNotNullResult[]> = books__sqlJS.UpdateBooksRankNotNull.many as any;
@@ -533,8 +517,6 @@ export const UpdateBooksRankNotNull_expectOne: (_1:PgTyped_Pg_Client_t, _2:updat
 /** Executes the query, but ignores whatever is returned by it. */
 export const UpdateBooksRankNotNull_execute: (_1:PgTyped_Pg_Client_t, _2:updateBooksRankNotNullParams) => Promise<void> = books__sqlJS.UpdateBooksRankNotNull.execute as any;
 
-export const updateBooksRankNotNull: (params:updateBooksRankNotNullParams, client:PgTyped_Pg_Client_t) => Promise<updateBooksRankNotNullResult[]> = books__sqlJS.updateBooksRankNotNull as any;
-
 /** Returns an array of all matched results. */
 export const GetBooksByAuthorName_many: (_1:PgTyped_Pg_Client_t, _2:getBooksByAuthorNameParams) => Promise<getBooksByAuthorNameResult[]> = books__sqlJS.GetBooksByAuthorName.many as any;
 
@@ -546,8 +528,6 @@ export const GetBooksByAuthorName_expectOne: (_1:PgTyped_Pg_Client_t, _2:getBook
 
 /** Executes the query, but ignores whatever is returned by it. */
 export const GetBooksByAuthorName_execute: (_1:PgTyped_Pg_Client_t, _2:getBooksByAuthorNameParams) => Promise<void> = books__sqlJS.GetBooksByAuthorName.execute as any;
-
-export const getBooksByAuthorName: (params:getBooksByAuthorNameParams, client:PgTyped_Pg_Client_t) => Promise<getBooksByAuthorNameResult[]> = books__sqlJS.getBooksByAuthorName as any;
 
 /** Returns an array of all matched results. */
 export const AggregateEmailsAndTest_many: (_1:PgTyped_Pg_Client_t, _2:aggregateEmailsAndTestParams) => Promise<aggregateEmailsAndTestResult[]> = books__sqlJS.AggregateEmailsAndTest.many as any;
@@ -561,8 +541,6 @@ export const AggregateEmailsAndTest_expectOne: (_1:PgTyped_Pg_Client_t, _2:aggre
 /** Executes the query, but ignores whatever is returned by it. */
 export const AggregateEmailsAndTest_execute: (_1:PgTyped_Pg_Client_t, _2:aggregateEmailsAndTestParams) => Promise<void> = books__sqlJS.AggregateEmailsAndTest.execute as any;
 
-export const aggregateEmailsAndTest: (params:aggregateEmailsAndTestParams, client:PgTyped_Pg_Client_t) => Promise<aggregateEmailsAndTestResult[]> = books__sqlJS.aggregateEmailsAndTest as any;
-
 /** Returns an array of all matched results. */
 export const GetBooks_many: (_1:PgTyped_Pg_Client_t, _2:getBooksParams) => Promise<getBooksResult[]> = books__sqlJS.GetBooks.many as any;
 
@@ -574,8 +552,6 @@ export const GetBooks_expectOne: (_1:PgTyped_Pg_Client_t, _2:getBooksParams, err
 
 /** Executes the query, but ignores whatever is returned by it. */
 export const GetBooks_execute: (_1:PgTyped_Pg_Client_t, _2:getBooksParams) => Promise<void> = books__sqlJS.GetBooks.execute as any;
-
-export const getBooks: (params:getBooksParams, client:PgTyped_Pg_Client_t) => Promise<getBooksResult[]> = books__sqlJS.getBooks as any;
 
 /** Returns an array of all matched results. */
 export const CountBooks_many: (_1:PgTyped_Pg_Client_t, _2:countBooksParams) => Promise<countBooksResult[]> = books__sqlJS.CountBooks.many as any;
@@ -589,8 +565,6 @@ export const CountBooks_expectOne: (_1:PgTyped_Pg_Client_t, _2:countBooksParams,
 /** Executes the query, but ignores whatever is returned by it. */
 export const CountBooks_execute: (_1:PgTyped_Pg_Client_t, _2:countBooksParams) => Promise<void> = books__sqlJS.CountBooks.execute as any;
 
-export const countBooks: (params:countBooksParams, client:PgTyped_Pg_Client_t) => Promise<countBooksResult[]> = books__sqlJS.countBooks as any;
-
 /** Returns an array of all matched results. */
 export const GetBookCountries_many: (_1:PgTyped_Pg_Client_t, _2:getBookCountriesParams) => Promise<getBookCountriesResult[]> = books__sqlJS.GetBookCountries.many as any;
 
@@ -602,8 +576,6 @@ export const GetBookCountries_expectOne: (_1:PgTyped_Pg_Client_t, _2:getBookCoun
 
 /** Executes the query, but ignores whatever is returned by it. */
 export const GetBookCountries_execute: (_1:PgTyped_Pg_Client_t, _2:getBookCountriesParams) => Promise<void> = books__sqlJS.GetBookCountries.execute as any;
-
-export const getBookCountries: (params:getBookCountriesParams, client:PgTyped_Pg_Client_t) => Promise<getBookCountriesResult[]> = books__sqlJS.getBookCountries as any;
 
 export const FindBookNameOrRank: {
   /** Returns exactly 1 result. Raises `Exn.t` (with an optionally provided `errorMessage`) if more or less than exactly 1 result is returned. */

--- a/packages/example/src/books/books__sql.res
+++ b/packages/example/src/books/books__sql.res
@@ -17,6 +17,7 @@ type intArray = array<int>
 @gentype
 type stringArray = array<string>
 
+
 /** 'FindBookById' parameters type */
 @gentype
 type findBookByIdParams = {
@@ -95,9 +96,6 @@ module FindBookById: {
   }
 }
 
-@gentype
-@deprecated("Use 'FindBookById.many' directly instead")
-let findBookById = (params, ~client) => FindBookById.many(client, params)
 
 
 /** 'FindBookByCategory' parameters type */
@@ -178,9 +176,6 @@ module FindBookByCategory: {
   }
 }
 
-@gentype
-@deprecated("Use 'FindBookByCategory.many' directly instead")
-let findBookByCategory = (params, ~client) => FindBookByCategory.many(client, params)
 
 
 /** 'FindBookNameOrRank' parameters type */
@@ -261,9 +256,6 @@ module FindBookNameOrRank: {
   }
 }
 
-@gentype
-@deprecated("Use 'FindBookNameOrRank.many' directly instead")
-let findBookNameOrRank = (params, ~client) => FindBookNameOrRank.many(client, params)
 
 
 /** 'FindBookUnicode' parameters type */
@@ -341,10 +333,6 @@ module FindBookUnicode: {
     let _ = await query(params, ~client)
   }
 }
-
-@gentype
-@deprecated("Use 'FindBookUnicode.many' directly instead")
-let findBookUnicode = (params, ~client) => FindBookUnicode.many(client, params)
 
 
 @gentype
@@ -429,9 +417,6 @@ module InsertBooks: {
   }
 }
 
-@gentype
-@deprecated("Use 'InsertBooks.many' directly instead")
-let insertBooks = (params, ~client) => InsertBooks.many(client, params)
 
 
 /** 'InsertBook' parameters type */
@@ -512,9 +497,6 @@ module InsertBook: {
   }
 }
 
-@gentype
-@deprecated("Use 'InsertBook.many' directly instead")
-let insertBook = (params, ~client) => InsertBook.many(client, params)
 
 
 /** 'UpdateBooksCustom' parameters type */
@@ -598,9 +580,6 @@ module UpdateBooksCustom: {
   }
 }
 
-@gentype
-@deprecated("Use 'UpdateBooksCustom.many' directly instead")
-let updateBooksCustom = (params, ~client) => UpdateBooksCustom.many(client, params)
 
 
 /** 'UpdateBooks' parameters type */
@@ -682,9 +661,6 @@ module UpdateBooks: {
   }
 }
 
-@gentype
-@deprecated("Use 'UpdateBooks.many' directly instead")
-let updateBooks = (params, ~client) => UpdateBooks.many(client, params)
 
 
 /** 'UpdateBooksRankNotNull' parameters type */
@@ -765,9 +741,6 @@ module UpdateBooksRankNotNull: {
   }
 }
 
-@gentype
-@deprecated("Use 'UpdateBooksRankNotNull.many' directly instead")
-let updateBooksRankNotNull = (params, ~client) => UpdateBooksRankNotNull.many(client, params)
 
 
 /** 'GetBooksByAuthorName' parameters type */
@@ -850,9 +823,6 @@ module GetBooksByAuthorName: {
   }
 }
 
-@gentype
-@deprecated("Use 'GetBooksByAuthorName.many' directly instead")
-let getBooksByAuthorName = (params, ~client) => GetBooksByAuthorName.many(client, params)
 
 
 /** 'AggregateEmailsAndTest' parameters type */
@@ -930,9 +900,6 @@ module AggregateEmailsAndTest: {
   }
 }
 
-@gentype
-@deprecated("Use 'AggregateEmailsAndTest.many' directly instead")
-let aggregateEmailsAndTest = (params, ~client) => AggregateEmailsAndTest.many(client, params)
 
 
 /** 'GetBooks' parameters type */
@@ -1008,9 +975,6 @@ module GetBooks: {
   }
 }
 
-@gentype
-@deprecated("Use 'GetBooks.many' directly instead")
-let getBooks = (params, ~client) => GetBooks.many(client, params)
 
 
 /** 'CountBooks' parameters type */
@@ -1085,9 +1049,6 @@ module CountBooks: {
   }
 }
 
-@gentype
-@deprecated("Use 'CountBooks.many' directly instead")
-let countBooks = (params, ~client) => CountBooks.many(client, params)
 
 
 /** 'GetBookCountries' parameters type */
@@ -1162,9 +1123,5 @@ module GetBookCountries: {
     let _ = await query(params, ~client)
   }
 }
-
-@gentype
-@deprecated("Use 'GetBookCountries.many' directly instead")
-let getBookCountries = (params, ~client) => GetBookCountries.many(client, params)
 
 

--- a/packages/example/src/comments/comments__sql.gen.tsx
+++ b/packages/example/src/comments/comments__sql.gen.tsx
@@ -72,8 +72,6 @@ export const GetAllComments_expectOne: (_1:PgTyped_Pg_Client_t, _2:getAllComment
 /** Executes the query, but ignores whatever is returned by it. */
 export const GetAllComments_execute: (_1:PgTyped_Pg_Client_t, _2:getAllCommentsParams) => Promise<void> = comments__sqlJS.GetAllComments.execute as any;
 
-export const getAllComments: (params:getAllCommentsParams, client:PgTyped_Pg_Client_t) => Promise<getAllCommentsResult[]> = comments__sqlJS.getAllComments as any;
-
 /** Returns an array of all matched results. */
 export const GetAllCommentsByIds_many: (_1:PgTyped_Pg_Client_t, _2:getAllCommentsByIdsParams) => Promise<getAllCommentsByIdsResult[]> = comments__sqlJS.GetAllCommentsByIds.many as any;
 
@@ -85,8 +83,6 @@ export const GetAllCommentsByIds_expectOne: (_1:PgTyped_Pg_Client_t, _2:getAllCo
 
 /** Executes the query, but ignores whatever is returned by it. */
 export const GetAllCommentsByIds_execute: (_1:PgTyped_Pg_Client_t, _2:getAllCommentsByIdsParams) => Promise<void> = comments__sqlJS.GetAllCommentsByIds.execute as any;
-
-export const getAllCommentsByIds: (params:getAllCommentsByIdsParams, client:PgTyped_Pg_Client_t) => Promise<getAllCommentsByIdsResult[]> = comments__sqlJS.getAllCommentsByIds as any;
 
 /** Returns an array of all matched results. */
 export const InsertComment_many: (_1:PgTyped_Pg_Client_t, _2:insertCommentParams) => Promise<insertCommentResult[]> = comments__sqlJS.InsertComment.many as any;
@@ -100,8 +96,6 @@ export const InsertComment_expectOne: (_1:PgTyped_Pg_Client_t, _2:insertCommentP
 /** Executes the query, but ignores whatever is returned by it. */
 export const InsertComment_execute: (_1:PgTyped_Pg_Client_t, _2:insertCommentParams) => Promise<void> = comments__sqlJS.InsertComment.execute as any;
 
-export const insertComment: (params:insertCommentParams, client:PgTyped_Pg_Client_t) => Promise<insertCommentResult[]> = comments__sqlJS.insertComment as any;
-
 /** Returns an array of all matched results. */
 export const SelectExistsTest_many: (_1:PgTyped_Pg_Client_t, _2:selectExistsTestParams) => Promise<selectExistsTestResult[]> = comments__sqlJS.SelectExistsTest.many as any;
 
@@ -113,8 +107,6 @@ export const SelectExistsTest_expectOne: (_1:PgTyped_Pg_Client_t, _2:selectExist
 
 /** Executes the query, but ignores whatever is returned by it. */
 export const SelectExistsTest_execute: (_1:PgTyped_Pg_Client_t, _2:selectExistsTestParams) => Promise<void> = comments__sqlJS.SelectExistsTest.execute as any;
-
-export const selectExistsTest: (params:selectExistsTestParams, client:PgTyped_Pg_Client_t) => Promise<selectExistsTestResult[]> = comments__sqlJS.selectExistsTest as any;
 
 export const SelectExistsTest: {
   /** Returns exactly 1 result. Raises `Exn.t` (with an optionally provided `errorMessage`) if more or less than exactly 1 result is returned. */

--- a/packages/example/src/comments/comments__sql.res
+++ b/packages/example/src/comments/comments__sql.res
@@ -2,6 +2,7 @@
 open PgTyped
 
 
+
 /** 'GetAllComments' parameters type */
 @gentype
 type getAllCommentsParams = {
@@ -79,9 +80,6 @@ module GetAllComments: {
   }
 }
 
-@gentype
-@deprecated("Use 'GetAllComments.many' directly instead")
-let getAllComments = (params, ~client) => GetAllComments.many(client, params)
 
 
 /** 'GetAllCommentsByIds' parameters type */
@@ -160,10 +158,6 @@ module GetAllCommentsByIds: {
     let _ = await query(params, ~client)
   }
 }
-
-@gentype
-@deprecated("Use 'GetAllCommentsByIds.many' directly instead")
-let getAllCommentsByIds = (params, ~client) => GetAllCommentsByIds.many(client, params)
 
 
 @gentype
@@ -250,9 +244,6 @@ module InsertComment: {
   }
 }
 
-@gentype
-@deprecated("Use 'InsertComment.many' directly instead")
-let insertComment = (params, ~client) => InsertComment.many(client, params)
 
 
 /** 'SelectExistsTest' parameters type */
@@ -326,9 +317,5 @@ module SelectExistsTest: {
     let _ = await query(params, ~client)
   }
 }
-
-@gentype
-@deprecated("Use 'SelectExistsTest.many' directly instead")
-let selectExistsTest = (params, ~client) => SelectExistsTest.many(client, params)
 
 

--- a/packages/example/src/notifications/notifications__sql.gen.tsx
+++ b/packages/example/src/notifications/notifications__sql.gen.tsx
@@ -68,8 +68,6 @@ export const SendNotifications_expectOne: (_1:PgTyped_Pg_Client_t, _2:sendNotifi
 /** Executes the query, but ignores whatever is returned by it. */
 export const SendNotifications_execute: (_1:PgTyped_Pg_Client_t, _2:sendNotificationsParams) => Promise<void> = notifications__sqlJS.SendNotifications.execute as any;
 
-export const sendNotifications: (params:sendNotificationsParams, client:PgTyped_Pg_Client_t) => Promise<sendNotificationsResult[]> = notifications__sqlJS.sendNotifications as any;
-
 /** Returns an array of all matched results. */
 export const GetNotifications_many: (_1:PgTyped_Pg_Client_t, _2:getNotificationsParams) => Promise<getNotificationsResult[]> = notifications__sqlJS.GetNotifications.many as any;
 
@@ -82,8 +80,6 @@ export const GetNotifications_expectOne: (_1:PgTyped_Pg_Client_t, _2:getNotifica
 /** Executes the query, but ignores whatever is returned by it. */
 export const GetNotifications_execute: (_1:PgTyped_Pg_Client_t, _2:getNotificationsParams) => Promise<void> = notifications__sqlJS.GetNotifications.execute as any;
 
-export const getNotifications: (params:getNotificationsParams, client:PgTyped_Pg_Client_t) => Promise<getNotificationsResult[]> = notifications__sqlJS.getNotifications as any;
-
 /** Returns an array of all matched results. */
 export const ThresholdFrogs_many: (_1:PgTyped_Pg_Client_t, _2:thresholdFrogsParams) => Promise<thresholdFrogsResult[]> = notifications__sqlJS.ThresholdFrogs.many as any;
 
@@ -95,8 +91,6 @@ export const ThresholdFrogs_expectOne: (_1:PgTyped_Pg_Client_t, _2:thresholdFrog
 
 /** Executes the query, but ignores whatever is returned by it. */
 export const ThresholdFrogs_execute: (_1:PgTyped_Pg_Client_t, _2:thresholdFrogsParams) => Promise<void> = notifications__sqlJS.ThresholdFrogs.execute as any;
-
-export const thresholdFrogs: (params:thresholdFrogsParams, client:PgTyped_Pg_Client_t) => Promise<thresholdFrogsResult[]> = notifications__sqlJS.thresholdFrogs as any;
 
 export const ThresholdFrogs: {
   /** Returns exactly 1 result. Raises `Exn.t` (with an optionally provided `errorMessage`) if more or less than exactly 1 result is returned. */

--- a/packages/example/src/notifications/notifications__sql.res
+++ b/packages/example/src/notifications/notifications__sql.res
@@ -86,9 +86,6 @@ module SendNotifications: {
   }
 }
 
-@gentype
-@deprecated("Use 'SendNotifications.many' directly instead")
-let sendNotifications = (params, ~client) => SendNotifications.many(client, params)
 
 
 /** 'GetNotifications' parameters type */
@@ -173,9 +170,6 @@ module GetNotifications: {
   }
 }
 
-@gentype
-@deprecated("Use 'GetNotifications.many' directly instead")
-let getNotifications = (params, ~client) => GetNotifications.many(client, params)
 
 
 /** 'ThresholdFrogs' parameters type */
@@ -256,9 +250,5 @@ module ThresholdFrogs: {
     let _ = await query(params, ~client)
   }
 }
-
-@gentype
-@deprecated("Use 'ThresholdFrogs.many' directly instead")
-let thresholdFrogs = (params, ~client) => ThresholdFrogs.many(client, params)
 
 

--- a/packages/example/src/rescript.test.res
+++ b/packages/example/src/rescript.test.res
@@ -262,3 +262,41 @@ testAsync("`expectOne` works in fail case", async () => {
 
   expect(result)->Expect.toBe(true)
 })
+
+testAsync("insert query with json_populate_recordset", async () => {
+  let (insertedBookId1, insertedBookId2) = switch await getClient()->BookService.insertBooks(
+    ~books=[
+      {
+        author_id: 1,
+        name: "A Brief History of Time: From the Big Bang to Black Holes",
+        rank: 1,
+        categories: [#novel, #"science-fiction"],
+      },
+      {
+        author_id: 1,
+        name: "A Brief History of Time: From the Big Bang to Black Holes 2",
+        rank: 2,
+        categories: [#"science-fiction"],
+      },
+    ],
+  ) {
+  | [{id: id1}, {id: id2}] => (id1, id2)
+  | _ => panic("Unexpected result inserting books")
+  }
+
+  switch await getClient()->Books.FindBookById.one({id: insertedBookId1}) {
+  | Some(insertedBook) =>
+    expect(insertedBook.name)->Expect.toEqual(
+      "A Brief History of Time: From the Big Bang to Black Holes",
+    )
+  | None => panic("Unexpected result fetching newly inserted book")
+  }
+
+  switch await getClient()->Books.FindBookById.one({id: insertedBookId2}) {
+  | Some(insertedBook) =>
+    expect(insertedBook.name)->Expect.toEqual(
+      "A Brief History of Time: From the Big Bang to Black Holes 2",
+    )
+  | None => panic("Unexpected result fetching newly inserted book")
+  }
+})

--- a/packages/example/src/rescript.test.res
+++ b/packages/example/src/rescript.test.res
@@ -300,3 +300,16 @@ testAsync("insert query with json_populate_recordset", async () => {
   | None => panic("Unexpected result fetching newly inserted book")
   }
 })
+
+testAsync("json array inputs work", async () => {
+  let result = await getClient()->Json.JsonExtract.one({
+    jsonData: JSON.Array([
+      JSON.Object(Dict.fromArray([("id", JSON.String("1")), ("name", JSON.String("John"))])),
+    ]),
+  })
+
+  expect(result)->Expect.toEqual({
+    "user_id": "1",
+    "user_name": "John",
+  })
+})

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -14,4 +14,6 @@ export {
   queryASTToIR,
   assert,
   TransformType,
+  InputParamTransforms,
+  InputParamTransform,
 } from './loader/sql/index.js';

--- a/packages/parser/src/loader/sql/index.ts
+++ b/packages/parser/src/loader/sql/index.ts
@@ -71,6 +71,14 @@ export interface QueryAST {
   usedParamSet: { [paramName: string]: true };
 }
 
+export type InputParamTransformStringify = {
+  type: 'stringify';
+};
+
+export type InputParamTransform = InputParamTransformStringify;
+
+export type InputParamTransforms = Record<string, InputParamTransform>;
+
 export interface ParamIR {
   name: string;
   transform: ParamTransform;
@@ -85,6 +93,7 @@ export interface QueryIR {
   statement: string;
   usedParamSet: QueryAST['usedParamSet'];
   queryName: string;
+  inputParamTransforms: InputParamTransforms | undefined;
 }
 
 interface ParseTree {
@@ -292,11 +301,15 @@ function parseText(text: string): SQLParseResult {
   };
 }
 
-export function queryASTToIR(query: SQLQueryAST): SQLQueryIR {
+export function queryASTToIR(
+  query: SQLQueryAST,
+  inputParamTransforms: InputParamTransforms | null,
+): SQLQueryIR {
   const { a: statementStart } = query.statement.loc;
 
   return {
     queryName: query.name,
+    inputParamTransforms: inputParamTransforms ?? undefined,
     usedParamSet: query.usedParamSet,
     params: query.params.map((param) => ({
       name: param.name,

--- a/packages/query/src/actions.ts
+++ b/packages/query/src/actions.ts
@@ -735,42 +735,35 @@ async function extraParameterInfo(query: Statement[]) {
   >();
 
   const visitor = astVisitor((v) => ({
-    select: async (s) => {
-      if ('from' in s) {
-        const from = s.from;
-        if (Array.isArray(from) && from.length === 1) {
-          const frm = from[0];
-          if (
-            frm.type === 'call' &&
-            (frm.function.name === 'json_populate_recordset' ||
-              frm.function.name === 'jsonb_populate_recordset' ||
-              frm.function.name === 'json_populate_record' ||
-              frm.function.name === 'jsonb_populate_record')
-          ) {
-            const [arg1, arg2] = frm.args;
-            if (
-              arg1.type === 'cast' &&
-              arg1.operand.type === 'null' &&
-              'name' in arg1.to &&
-              arg2.type === 'parameter' &&
-              'name' in arg2
-            ) {
-              const assignedIndex = parseInt(arg2.name.slice(1), 10);
-              const name = arg1.to.name;
-              paramsInfo.set(assignedIndex, {
-                recordName: name,
-                assignedIndex,
-                multi:
-                  frm.function.name === 'json_populate_recordset' ||
-                  frm.function.name === 'jsonb_populate_recordset',
-                stringify: true,
-              });
-            }
-          }
+    call: async (c) => {
+      if (
+        c.function.name === 'json_populate_recordset' ||
+        c.function.name === 'jsonb_populate_recordset' ||
+        c.function.name === 'json_populate_record' ||
+        c.function.name === 'jsonb_populate_record'
+      ) {
+        const [arg1, arg2] = c.args;
+        if (
+          arg1.type === 'cast' &&
+          arg1.operand.type === 'null' &&
+          'name' in arg1.to &&
+          arg2.type === 'parameter' &&
+          'name' in arg2
+        ) {
+          const assignedIndex = parseInt(arg2.name.slice(1), 10);
+          const name = arg1.to.name;
+          paramsInfo.set(assignedIndex, {
+            recordName: name,
+            assignedIndex,
+            multi:
+              c.function.name === 'json_populate_recordset' ||
+              c.function.name === 'jsonb_populate_recordset',
+            stringify: true,
+          });
         }
       }
 
-      v.super().select(s);
+      v.super().call(c);
     },
   }));
 

--- a/packages/query/src/actions.ts
+++ b/packages/query/src/actions.ts
@@ -175,6 +175,23 @@ export interface IQueryTypes {
     nullable?: boolean;
     comment?: string;
     checkValues?: ConstraintValue[];
+    defaultValue?: string;
+  }>;
+  inputTypes?: Record<string, IInputTypes>;
+}
+
+export interface IInputTypes {
+  tableName: string;
+  assignedIndex: number;
+  multi: boolean;
+  stringify: boolean;
+  fields: Array<{
+    columnName: string;
+    type: MappableType;
+    optional?: boolean;
+    comment?: string;
+    checkValues?: ConstraintValue[];
+    defaultValue?: string;
   }>;
 }
 
@@ -517,6 +534,12 @@ interface ColumnComment {
   comment: string;
 }
 
+interface ColumnDefault {
+  tableOID: number;
+  columnAttrNumber: number;
+  defaultValue: string | null;
+}
+
 async function getComments(
   fields: TypeField[],
   queue: AsyncQueue,
@@ -542,6 +565,38 @@ async function getComments(
     tableOID: Number(row[0]),
     columnAttrNumber: Number(row[1]),
     comment: row[2],
+  }));
+}
+
+async function getDefaults(
+  fields: TypeField[],
+  queue: AsyncQueue,
+): Promise<ColumnDefault[]> {
+  const columnFields = fields.filter((f) => f.columnAttrNumber > 0);
+  if (columnFields.length === 0) {
+    return [];
+  }
+
+  const tableOids = Array.from(
+    new Set(columnFields.map((f) => f.tableOID)),
+  ).join(',');
+
+  const defaultRows = await runQuery(
+    `SELECT
+      attrelid, attnum, atthasdef, 
+      CASE WHEN atthasdef THEN pg_get_expr(adbin, attrelid) ELSE NULL END as default_value
+     FROM pg_attribute a
+     LEFT JOIN pg_attrdef ad ON a.attrelid = ad.adrelid AND a.attnum = ad.adnum
+     WHERE a.attrelid IN (${tableOids}) 
+       AND a.attnum > 0 
+       AND NOT a.attisdropped;`,
+    queue,
+  );
+
+  return defaultRows.map((row) => ({
+    tableOID: Number(row[0]),
+    columnAttrNumber: Number(row[1]),
+    defaultValue: row[3],
   }));
 }
 
@@ -668,6 +723,61 @@ export function getAliasedLiterals(
   return map;
 }
 
+async function extraParameterInfo(query: Statement[]) {
+  const paramsInfo = new Map<
+    number,
+    {
+      recordName: string;
+      assignedIndex: number;
+      multi: boolean;
+      stringify: boolean;
+    }
+  >();
+
+  const visitor = astVisitor((v) => ({
+    select: async (s) => {
+      if ('from' in s) {
+        const from = s.from;
+        if (Array.isArray(from) && from.length === 1) {
+          const frm = from[0];
+          if (
+            frm.type === 'call' &&
+            (frm.function.name === 'json_populate_recordset' ||
+              frm.function.name === 'jsonb_populate_recordset' ||
+              frm.function.name === 'json_populate_record' ||
+              frm.function.name === 'jsonb_populate_record')
+          ) {
+            const [arg1, arg2] = frm.args;
+            if (
+              arg1.type === 'cast' &&
+              arg1.operand.type === 'null' &&
+              'name' in arg1.to &&
+              arg2.type === 'parameter' &&
+              'name' in arg2
+            ) {
+              const assignedIndex = parseInt(arg2.name.slice(1), 10);
+              const name = arg1.to.name;
+              paramsInfo.set(assignedIndex, {
+                recordName: name,
+                assignedIndex,
+                multi:
+                  frm.function.name === 'json_populate_recordset' ||
+                  frm.function.name === 'jsonb_populate_recordset',
+                stringify: true,
+              });
+            }
+          }
+        }
+      }
+
+      v.super().select(s);
+    },
+  }));
+
+  visitor.statement(query[0]);
+  return paramsInfo;
+}
+
 export async function getTypes(
   queryData: InterpolatedQuery,
   queue: AsyncQueue,
@@ -688,6 +798,7 @@ export async function getTypes(
   const typeMap = reduceTypeRows(typeRows);
   const parsedQuery = parse(queryData.query);
   const aliasedLiterals = getAliasedLiterals(parsedQuery);
+  const paramsInfo = await extraParameterInfo(parsedQuery);
 
   const attrMatcher = ({
     tableOID,
@@ -754,12 +865,166 @@ export async function getTypes(
       }
     });
 
+  const inputTypes: Record<string, IInputTypes> = {};
+
+  if (paramsInfo.size > 0) {
+    for (const [_, { recordName, assignedIndex, multi }] of paramsInfo) {
+      const paramTypeInfo = await getInputType(
+        recordName,
+        assignedIndex,
+        queue,
+      );
+      if ('errorCode' in paramTypeInfo) {
+        // Ignore errors for now
+      } else {
+        inputTypes[assignedIndex] = { ...paramTypeInfo, multi };
+      }
+    }
+  }
+
+  const processedMapping = queryData.mapping.map((param) => {
+    if (
+      'assignedIndex' in param &&
+      !Array.isArray(param.assignedIndex) &&
+      paramsInfo.has(param.assignedIndex)
+    ) {
+      const paramInfo = paramsInfo.get(param.assignedIndex)!;
+
+      return {
+        type: 'inputTypeReference' as const,
+        tableName: paramInfo.recordName,
+        assignedIndex: param.assignedIndex,
+        name: param.name,
+        stringify: paramInfo.stringify,
+      };
+    }
+    return param;
+  });
+
   const paramMetadata = {
     params: params.map(({ oid }) => typeMap[oid]),
-    mapping: queryData.mapping,
+    mapping: processedMapping,
   };
 
-  return { paramMetadata, returnTypes };
+  return { paramMetadata, returnTypes, inputTypes };
+}
+
+export async function getInputType(
+  tableName: string,
+  assignedIndex: number,
+  queue: AsyncQueue,
+): Promise<IInputTypes | IParseError> {
+  try {
+    // First, get the table OID
+    const tableOidRows = await runQuery(
+      `SELECT oid FROM pg_class WHERE relname = '${tableName}' AND relkind = 'r';`,
+      queue,
+    );
+
+    if (tableOidRows.length === 0) {
+      return {
+        errorCode: 'TABLE_NOT_FOUND',
+        message: `Table '${tableName}' not found`,
+      };
+    }
+
+    const tableOID = Number(tableOidRows[0][0]);
+
+    // Get all columns for the table
+    const columnRows = await runQuery(
+      `SELECT 
+        attrelid as table_oid,
+        attnum as column_attr_number, 
+        atttypid as type_oid,
+        attname as name,
+        attnotnull,
+        atthasdef
+       FROM pg_attribute 
+       WHERE attrelid = ${tableOID}
+         AND attnum > 0 
+         AND NOT attisdropped
+       ORDER BY attnum;`,
+      queue,
+    );
+
+    if (columnRows.length === 0) {
+      return {
+        errorCode: 'NO_COLUMNS_FOUND',
+        message: `No columns found for table '${tableName}'`,
+      };
+    }
+
+    // Create TypeField-like objects for compatibility with existing functions
+    const fields = columnRows.map((row) => ({
+      name: row[3], // attname
+      tableOID: Number(row[0]), // attrelid
+      columnAttrNumber: Number(row[1]), // attnum
+      typeOID: Number(row[2]), // atttypid
+      typeSize: 0, // not needed for input types
+      typeModifier: 0, // not needed for input types
+      formatCode: 0, // not needed for input types
+    }));
+
+    // Get type information
+    const returnTypesOIDs = fields.map((f) => f.typeOID);
+    const typeRows = await runTypesCatalogQuery(returnTypesOIDs, queue);
+    const commentRows = await getComments(fields, queue);
+    const checkRows = await getCheckConstraints(fields, queue);
+    const defaultRows = await getDefaults(fields, queue);
+    const typeMap = reduceTypeRows(typeRows);
+
+    const getAttid = (col: Pick<TypeField, 'tableOID' | 'columnAttrNumber'>) =>
+      `${col.tableOID}:${col.columnAttrNumber}`;
+
+    // Create maps for lookups
+    const commentMap: { [attid: string]: string | undefined } = {};
+    for (const c of commentRows) {
+      commentMap[`${c.tableOID}:${c.columnAttrNumber}`] = c.comment;
+    }
+    const checkMap: { [attid: string]: ConstraintValue[] } = {};
+    for (const chk of checkRows) {
+      checkMap[`${chk.tableOID}:${chk.columnAttrNumber}`] = chk.values;
+    }
+    const defaultMap: { [attid: string]: ColumnDefault } = {};
+    for (const def of defaultRows) {
+      defaultMap[`${def.tableOID}:${def.columnAttrNumber}`] = def;
+    }
+
+    // Build input types - key difference: optionality based on NOT NULL + defaults
+    const inputTypes = fields.map((f, index) => {
+      const hasDefault = !!defaultMap[getAttid(f)]?.defaultValue;
+      const isNotNull = columnRows[index][4] === 't'; // attnotnull
+
+      return {
+        columnName: f.name,
+        type: typeMap[f.typeOID],
+        // Column is optional if it has a default OR allows NULL
+        optional: hasDefault || !isNotNull,
+        ...(commentMap[getAttid(f)]
+          ? { comment: commentMap[getAttid(f)] }
+          : {}),
+        ...(checkMap[getAttid(f)]
+          ? { checkValues: checkMap[getAttid(f)] }
+          : {}),
+        ...(defaultMap[getAttid(f)]?.defaultValue
+          ? { defaultValue: defaultMap[getAttid(f)].defaultValue! }
+          : {}),
+      };
+    });
+
+    return {
+      tableName,
+      assignedIndex,
+      multi: false,
+      fields: inputTypes,
+      stringify: true,
+    };
+  } catch (error) {
+    return {
+      errorCode: 'QUERY_ERROR',
+      message: `Error querying table '${tableName}': ${(error as any).message}`,
+    };
+  }
 }
 
 function toRescriptName(name: string): string {

--- a/packages/query/src/actions.ts
+++ b/packages/query/src/actions.ts
@@ -888,7 +888,6 @@ export async function getTypes(
         tableName: paramInfo.recordName,
         assignedIndex: param.assignedIndex,
         name: param.name,
-        stringify: paramInfo.stringify,
       };
     }
     return param;

--- a/packages/runtime/src/preprocessor-sql.test.ts
+++ b/packages/runtime/src/preprocessor-sql.test.ts
@@ -21,7 +21,7 @@ test('(SQL) no params', () => {
     name: 'selectSomeUsers',
   };
 
-  const queryIR = queryASTToIR(fileAST.queries[0]);
+  const queryIR = queryASTToIR(fileAST.queries[0], null);
   const interpolationResult = processSQLQueryIR(queryIR, parameters);
   const mappingResult = processSQLQueryIR(queryIR);
 
@@ -55,7 +55,7 @@ test('(SQL) two scalar params, one forced as non-null', () => {
     name: 'UpdateBooksRankNotNull',
   };
 
-  const queryIR = queryASTToIR(fileAST.queries[0]);
+  const queryIR = queryASTToIR(fileAST.queries[0], null);
   const interpolationResult = processSQLQueryIR(queryIR, parameters);
 
   expect(interpolationResult).toEqual(expectedInterpolationResult);
@@ -99,7 +99,7 @@ test('(SQL) two scalar params', () => {
     name: 'selectSomeUsers',
   };
 
-  const queryIR = queryASTToIR(fileAST.queries[0]);
+  const queryIR = queryASTToIR(fileAST.queries[0], null);
   const interpolationResult = processSQLQueryIR(queryIR, parameters);
   const mappingResult = processSQLQueryIR(queryIR);
 
@@ -138,7 +138,7 @@ test('(SQL) one param used twice', () => {
     name: 'selectUsersAndParents',
   };
 
-  const queryIR = queryASTToIR(fileAST.queries[0]);
+  const queryIR = queryASTToIR(fileAST.queries[0], null);
   const interpolationResult = processSQLQueryIR(queryIR, parameters);
   const mappingResult = processSQLQueryIR(queryIR);
 
@@ -180,7 +180,7 @@ test('(SQL) array param', () => {
     name: 'selectSomeUsers',
   };
 
-  const queryIR = queryASTToIR(fileAST.queries[0]);
+  const queryIR = queryASTToIR(fileAST.queries[0], null);
   const interpolationResult = processSQLQueryIR(queryIR, parameters);
   const mappingResult = processSQLQueryIR(queryIR);
 
@@ -222,7 +222,7 @@ test('(SQL) array param used twice', () => {
     name: 'selectSomeUsers',
   };
 
-  const queryIR = queryASTToIR(fileAST.queries[0]);
+  const queryIR = queryASTToIR(fileAST.queries[0], null);
   const interpolationResult = processSQLQueryIR(queryIR, parameters);
   const mappingResult = processSQLQueryIR(queryIR);
 
@@ -271,7 +271,7 @@ test('(SQL) array and scalar param', () => {
     name: 'selectSomeUsers',
   };
 
-  const queryIR = queryASTToIR(fileAST.queries[0]);
+  const queryIR = queryASTToIR(fileAST.queries[0], null);
   const interpolationResult = processSQLQueryIR(queryIR, parameters);
   const mappingResult = processSQLQueryIR(queryIR);
 
@@ -325,7 +325,7 @@ test('(SQL) pick param', () => {
     name: 'insertUsers',
   };
 
-  const queryIR = queryASTToIR(fileAST.queries[0]);
+  const queryIR = queryASTToIR(fileAST.queries[0], null);
   const interpolationResult = processSQLQueryIR(queryIR, parameters);
   expect(interpolationResult).toEqual(expectedInterpolationResult);
 
@@ -379,7 +379,7 @@ test('(SQL) pick param used twice', () => {
     name: 'insertUsersTwice',
   };
 
-  const queryIR = queryASTToIR(fileAST.queries[0]);
+  const queryIR = queryASTToIR(fileAST.queries[0], null);
   const interpolationResult = processSQLQueryIR(queryIR, parameters);
   expect(interpolationResult).toEqual(expectedInterpolationResult);
 
@@ -438,7 +438,7 @@ test('(SQL) pickSpread param', () => {
     name: 'insertUsers',
   };
 
-  const queryIR = queryASTToIR(fileAST.queries[0]);
+  const queryIR = queryASTToIR(fileAST.queries[0], null);
   const interpolationResult = processSQLQueryIR(queryIR, parameters);
   const mappingResult = processSQLQueryIR(queryIR);
 
@@ -498,7 +498,7 @@ test('(SQL) pickSpread param used twice', () => {
     name: 'insertUsers',
   };
 
-  const queryIR = queryASTToIR(fileAST.queries[0]);
+  const queryIR = queryASTToIR(fileAST.queries[0], null);
   const interpolationResult = processSQLQueryIR(queryIR, parameters);
   const mappingResult = processSQLQueryIR(queryIR);
 
@@ -537,7 +537,7 @@ test('(SQL) scalar param required and optional', () => {
     name: 'selectSomeUsers',
   };
 
-  const queryIR = queryASTToIR(fileAST.queries[0]);
+  const queryIR = queryASTToIR(fileAST.queries[0], null);
   const interpolationResult = processSQLQueryIR(queryIR, parameters);
   const mappingResult = processSQLQueryIR(queryIR);
 
@@ -591,7 +591,7 @@ test('(SQL) pick param required', () => {
     name: 'insertUsers',
   };
 
-  const queryIR = queryASTToIR(fileAST.queries[0]);
+  const queryIR = queryASTToIR(fileAST.queries[0], null);
   const interpolationResult = processSQLQueryIR(queryIR, parameters);
   expect(interpolationResult).toEqual(expectedInterpolationResult);
 
@@ -633,7 +633,7 @@ test('(SQL) array param required', () => {
     name: 'selectSomeUsers',
   };
 
-  const queryIR = queryASTToIR(fileAST.queries[0]);
+  const queryIR = queryASTToIR(fileAST.queries[0], null);
   const interpolationResult = processSQLQueryIR(queryIR, parameters);
   const mappingResult = processSQLQueryIR(queryIR);
 

--- a/packages/runtime/src/preprocessor-sql.ts
+++ b/packages/runtime/src/preprocessor-sql.ts
@@ -1,4 +1,9 @@
-import { assert, SQLQueryIR, TransformType } from '@pgtyped/parser';
+import {
+  assert,
+  SQLQueryIR,
+  TransformType,
+  InputParamTransform,
+} from '@pgtyped/parser';
 import {
   InterpolatedQuery,
   NestedParameters,
@@ -10,6 +15,18 @@ import {
   replaceIntervals,
   Scalar,
 } from './preprocessor.js';
+
+function transformInputParam(
+  val: Scalar,
+  inputTypeTransform: InputParamTransform | undefined,
+) {
+  switch (inputTypeTransform?.type) {
+    case 'stringify':
+      return JSON.stringify(val);
+    default:
+      return val;
+  }
+}
 
 /* Processes query AST formed by new parser from pure SQL files */
 export const processSQLQueryIR = (
@@ -145,9 +162,15 @@ export const processSQLQueryIR = (
 
     // Handle scalar transform
     const assignedIndex = i++;
+    const inputTypeTransform =
+      queryIR.inputParamTransforms?.[assignedIndex.toString()];
+
     if (passedParams) {
       const paramValue = passedParams[usedParam.name] as Scalar;
-      bindings.push(paramValue);
+
+      // Transforms are only applied to scalars, because the intention is to remove
+      // the other transforms above.
+      bindings.push(transformInputParam(paramValue, inputTypeTransform));
     } else {
       paramMapping.push({
         name: usedParam.name,

--- a/packages/runtime/src/preprocessor.ts
+++ b/packages/runtime/src/preprocessor.ts
@@ -14,6 +14,13 @@ export interface ScalarParameter {
   assignedIndex: number;
 }
 
+export interface InputTypeReferenceParameter {
+  type: 'inputTypeReference';
+  name: string;
+  tableName: string;
+  assignedIndex: number;
+}
+
 export interface DictParameter {
   name: string;
   type: ParameterTransform.Pick;
@@ -40,7 +47,8 @@ export type QueryParameter =
   | ScalarParameter
   | ScalarArrayParameter
   | DictParameter
-  | DictArrayParameter;
+  | DictArrayParameter
+  | InputTypeReferenceParameter;
 
 export interface InterpolatedQuery {
   query: string;


### PR DESCRIPTION
Enables ergonomic and type safe creation queries, including for batching.