### PR TITLE
Add OIDC tag release workflow with dry run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,131 @@
+name: Release
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/release.yml'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'packages/**'
+  workflow_dispatch:
+  push:
+    tags:
+      - '[0-9]*.[0-9]*.[0-9]*'
+      - 'v[0-9]*.[0-9]*.[0-9]*'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  checks:
+    name: Build and test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm ci
+
+      - name: Validate release tag
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          cli_version="$(node -p "require('./packages/cli/package.json').version")"
+
+          if [ "$tag" != "$cli_version" ]; then
+            echo "Tag $GITHUB_REF_NAME does not match pgtyped-rescript version $cli_version"
+            exit 1
+          fi
+
+      - name: Build packages
+        run: npm run build
+
+      - name: Run tests
+        run: npm test
+        env:
+          NODE_VERSION: '20'
+
+  dry-run:
+    name: Publish dry run
+    needs: checks
+    if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm ci
+      - run: npm run build
+
+      - name: Dry-run publish packages
+        run: |
+          set -euo pipefail
+
+          for package_dir in \
+            packages/wire \
+            packages/parser \
+            packages/runtime \
+            packages/query \
+            packages/cli
+          do
+            package_name="$(node -p "require('./${package_dir}/package.json').name")"
+            package_version="$(node -p "require('./${package_dir}/package.json').version")"
+
+            echo "Dry-running ${package_name}@${package_version}"
+            npm publish "./${package_dir}" --access public --dry-run
+          done
+
+  publish:
+    name: Publish to npm
+    needs: checks
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    environment: npm
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm ci
+      - run: npm run build
+
+      - name: Publish packages with npm trusted publishing
+        run: |
+          set -euo pipefail
+
+          for package_dir in \
+            packages/wire \
+            packages/parser \
+            packages/runtime \
+            packages/query \
+            packages/cli
+          do
+            package_name="$(node -p "require('./${package_dir}/package.json').name")"
+            package_version="$(node -p "require('./${package_dir}/package.json').version")"
+
+            if npm view "${package_name}@${package_version}" version >/dev/null 2>&1; then
+              echo "${package_name}@${package_version} is already published; skipping"
+              continue
+            fi
+
+            echo "Publishing ${package_name}@${package_version}"
+            npm publish "./${package_dir}" --access public --provenance
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,6 +161,7 @@ jobs:
       - name: Publish packages with npm trusted publishing
         run: |
           set -euo pipefail
+          release_version="${GITHUB_REF_NAME#v}"
 
           for package_dir in \
             packages/wire \
@@ -171,6 +172,11 @@ jobs:
           do
             package_name="$(node -p "require('./${package_dir}/package.json').name")"
             package_version="$(node -p "require('./${package_dir}/package.json').version")"
+
+            if [ "$package_version" != "$release_version" ]; then
+              echo "Skipping ${package_name}@${package_version}; tag ${GITHUB_REF_NAME} releases ${release_version}"
+              continue
+            fi
 
             if npm view "${package_name}@${package_version}" version >/dev/null 2>&1; then
               echo "${package_name}@${package_version} is already published; skipping"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,12 +37,29 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         run: |
           tag="${GITHUB_REF_NAME#v}"
-          cli_version="$(node -p "require('./packages/cli/package.json').version")"
+          matched_package=""
 
-          if [ "$tag" != "$cli_version" ]; then
-            echo "Tag $GITHUB_REF_NAME does not match pgtyped-rescript version $cli_version"
+          for package_dir in \
+            packages/wire \
+            packages/parser \
+            packages/runtime \
+            packages/query \
+            packages/cli
+          do
+            package_name="$(node -p "require('./${package_dir}/package.json').name")"
+            package_version="$(node -p "require('./${package_dir}/package.json').version")"
+
+            if [ "$tag" = "$package_version" ]; then
+              matched_package="${matched_package}${matched_package:+, }${package_name}@${package_version}"
+            fi
+          done
+
+          if [ -z "$matched_package" ]; then
+            echo "Tag $GITHUB_REF_NAME does not match any publishable package version"
             exit 1
           fi
+
+          echo "Tag $GITHUB_REF_NAME matches ${matched_package}"
 
       - name: Build packages
         run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,12 @@ jobs:
             package_version="$(node -p "require('./${package_dir}/package.json').version")"
 
             echo "Dry-running ${package_name}@${package_version}"
+            if npm view "${package_name}@${package_version}" version >/dev/null 2>&1; then
+              echo "${package_name}@${package_version} is already published; validating package contents only"
+              npm pack "./${package_dir}" --dry-run
+              continue
+            fi
+
             npm publish "./${package_dir}" --access public --dry-run
           done
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   package-checks:
@@ -145,6 +144,9 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     environment: npm
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
@@ -128,7 +128,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,8 @@ permissions:
   id-token: write
 
 jobs:
-  checks:
-    name: Build and test
+  package-checks:
+    name: Package build and test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -47,14 +47,40 @@ jobs:
       - name: Build packages
         run: npm run build
 
-      - name: Run tests
+      - name: Run lint
+        run: npm run lint
+
+      - name: Run package tests
+        run: npx lerna run test --ignore @pgtyped/example --stream
+        env:
+          NODE_VERSION: '20'
+
+  full-tests:
+    name: Full test suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm ci
+
+      - name: Build packages
+        run: npm run build
+
+      - name: Run full test suite
         run: npm test
         env:
           NODE_VERSION: '20'
 
   dry-run:
     name: Publish dry run
-    needs: checks
+    needs: package-checks
     if: ${{ !startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
     steps:
@@ -90,7 +116,9 @@ jobs:
 
   publish:
     name: Publish to npm
-    needs: checks
+    needs:
+      - package-checks
+      - full-tests
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     environment: npm

--- a/packages/example/src/PgTyped.gen.tsx
+++ b/packages/example/src/PgTyped.gen.tsx
@@ -1,0 +1,4 @@
+import type {Client} from 'pg';
+
+export type Pg_Client_t = Client;
+export type dateOrString = string;

--- a/packages/example/src/books/BookServiceParams2__sql.gen.tsx
+++ b/packages/example/src/books/BookServiceParams2__sql.gen.tsx
@@ -5,7 +5,7 @@
 
 const BookServiceParams2__sqlJS = require('./BookServiceParams2__sql.js');
 
-import type {Pg_Client_t as PgTyped_Pg_Client_t} from 'pgtyped-rescript/src/res/PgTyped.gen';
+import type {Pg_Client_t as PgTyped_Pg_Client_t} from './PgTyped.gen';
 
 export type notification_type = "deadline" | "notification" | "reminder";
 

--- a/packages/example/src/books/BookServiceParams__sql.gen.tsx
+++ b/packages/example/src/books/BookServiceParams__sql.gen.tsx
@@ -5,7 +5,7 @@
 
 const BookServiceParams__sqlJS = require('./BookServiceParams__sql.js');
 
-import type {Pg_Client_t as PgTyped_Pg_Client_t} from 'pgtyped-rescript/src/res/PgTyped.gen';
+import type {Pg_Client_t as PgTyped_Pg_Client_t} from './PgTyped.gen';
 
 export type notification_type = "deadline" | "notification" | "reminder";
 

--- a/packages/example/src/books/BookService__sql.gen.tsx
+++ b/packages/example/src/books/BookService__sql.gen.tsx
@@ -5,7 +5,7 @@
 
 const BookService__sqlJS = require('./BookService__sql.js');
 
-import type {Pg_Client_t as PgTyped_Pg_Client_t} from 'pgtyped-rescript/src/res/PgTyped.gen';
+import type {Pg_Client_t as PgTyped_Pg_Client_t} from './PgTyped.gen';
 
 export type category = "novel" | "science-fiction" | "thriller";
 

--- a/packages/example/src/books/Dump__sql.gen.tsx
+++ b/packages/example/src/books/Dump__sql.gen.tsx
@@ -5,7 +5,7 @@
 
 const Dump__sqlJS = require('./Dump__sql.js');
 
-import type {Pg_Client_t as PgTyped_Pg_Client_t} from 'pgtyped-rescript/src/res/PgTyped.gen';
+import type {Pg_Client_t as PgTyped_Pg_Client_t} from './PgTyped.gen';
 
 export type arrayJSON_t = unknown[];
 

--- a/packages/example/src/books/Json__sql.gen.tsx
+++ b/packages/example/src/books/Json__sql.gen.tsx
@@ -5,7 +5,7 @@
 
 const Json__sqlJS = require('./Json__sql.js');
 
-import type {Pg_Client_t as PgTyped_Pg_Client_t} from 'pgtyped-rescript/src/res/PgTyped.gen';
+import type {Pg_Client_t as PgTyped_Pg_Client_t} from './PgTyped.gen';
 
 export type category = "novel" | "science-fiction" | "thriller";
 

--- a/packages/example/src/books/Keywords__sql.gen.tsx
+++ b/packages/example/src/books/Keywords__sql.gen.tsx
@@ -5,7 +5,7 @@
 
 const Keywords__sqlJS = require('./Keywords__sql.js');
 
-import type {Pg_Client_t as PgTyped_Pg_Client_t} from 'pgtyped-rescript/src/res/PgTyped.gen';
+import type {Pg_Client_t as PgTyped_Pg_Client_t} from './PgTyped.gen';
 
 /** 'Keywords' parameters type */
 export type keywordsParams = void;

--- a/packages/example/src/books/Misc__sql.gen.tsx
+++ b/packages/example/src/books/Misc__sql.gen.tsx
@@ -5,7 +5,7 @@
 
 const Misc__sqlJS = require('./Misc__sql.js');
 
-import type {Pg_Client_t as PgTyped_Pg_Client_t} from 'pgtyped-rescript/src/res/PgTyped.gen';
+import type {Pg_Client_t as PgTyped_Pg_Client_t} from './PgTyped.gen';
 
 /** 'Literals' parameters type */
 export type literalsParams = void;

--- a/packages/example/src/books/PgTyped.gen.tsx
+++ b/packages/example/src/books/PgTyped.gen.tsx
@@ -1,0 +1,1 @@
+export type {Pg_Client_t, dateOrString} from '../PgTyped.gen';

--- a/packages/example/src/books/books__sql.gen.tsx
+++ b/packages/example/src/books/books__sql.gen.tsx
@@ -5,7 +5,7 @@
 
 const books__sqlJS = require('./books__sql.js');
 
-import type {Pg_Client_t as PgTyped_Pg_Client_t} from 'pgtyped-rescript/src/res/PgTyped.gen';
+import type {Pg_Client_t as PgTyped_Pg_Client_t} from './PgTyped.gen';
 
 export type category = "novel" | "science-fiction" | "thriller";
 

--- a/packages/example/src/comments/PgTyped.gen.tsx
+++ b/packages/example/src/comments/PgTyped.gen.tsx
@@ -1,0 +1,1 @@
+export type {Pg_Client_t, dateOrString} from '../PgTyped.gen';

--- a/packages/example/src/comments/comments__sql.gen.tsx
+++ b/packages/example/src/comments/comments__sql.gen.tsx
@@ -5,7 +5,7 @@
 
 const comments__sqlJS = require('./comments__sql.js');
 
-import type {Pg_Client_t as PgTyped_Pg_Client_t} from 'pgtyped-rescript/src/res/PgTyped.gen';
+import type {Pg_Client_t as PgTyped_Pg_Client_t} from './PgTyped.gen';
 
 /** 'GetAllComments' parameters type */
 export type getAllCommentsParams = { readonly id: number };

--- a/packages/example/src/notifications/PgTyped.gen.tsx
+++ b/packages/example/src/notifications/PgTyped.gen.tsx
@@ -1,0 +1,1 @@
+export type {Pg_Client_t, dateOrString} from '../PgTyped.gen';

--- a/packages/example/src/notifications/notifications__sql.gen.tsx
+++ b/packages/example/src/notifications/notifications__sql.gen.tsx
@@ -5,9 +5,9 @@
 
 const notifications__sqlJS = require('./notifications__sql.js');
 
-import type {Pg_Client_t as PgTyped_Pg_Client_t} from 'pgtyped-rescript/src/res/PgTyped.gen';
+import type {Pg_Client_t as PgTyped_Pg_Client_t} from './PgTyped.gen';
 
-import type {dateOrString as PgTyped_dateOrString} from 'pgtyped-rescript/src/res/PgTyped.gen';
+import type {dateOrString as PgTyped_dateOrString} from './PgTyped.gen';
 
 export type notification_type = "deadline" | "notification" | "reminder";
 


### PR DESCRIPTION
Adds a tag-triggered npm release workflow that uses npm trusted publishing/OIDC instead of an npm token.\n\nSafety behavior:\n- PR and manual workflow runs execute build/test and npm publish --dry-run only.\n- Semver tag pushes validate the tag against packages/cli/package.json, run build/test, then publish.\n- Real publishing uses npm trusted publishing with --provenance and no NODE_AUTH_TOKEN/NPM_TOKEN.\n- Existing package versions are skipped during real publish.\n\nBefore merging, configure npm trusted publishers for the public packages to allow this repository/workflow, with environment npm if keeping the environment gate.