### PR TITLE
Fix Pg.Pool connection string binding

### DIFF
--- a/packages/cli/src/res/PgTyped.res
+++ b/packages/cli/src/res/PgTyped.res
@@ -48,7 +48,7 @@ module Pg = {
     @module("pg") @new external make: pgConfig => t = "Client"
     @send external connect: t => promise<unit> = "connect"
     @send external end: t => promise<unit> = "end"
-    @send external release: t => promise<unit> = "release"
+    @send external release: t => unit = "release"
 
     /** Bind when needed. */
     type typeParsers
@@ -81,12 +81,25 @@ module Pg = {
     type t
 
     type config = {
-      /** all valid client config options are also valid here
-   in addition here are the pool specific configuration parameters:
- 
-   number of milliseconds to wait before timing out when connecting a new client
-   by default this is 0 which means no timeout*/
+      /** default process.env.PGUSER || process.env.USER*/ user?: string,
+      /**default process.env.PGPASSWORD*/ password?: string,
+      /** default process.env.PGHOST*/ host?: string,
+      /** default process.env.PGPORT*/ port?: int,
+      /** default process.env.PGDATABASE || user*/ database?: string,
+      /** e.g. postgres://user:password@host:5432/database*/ connectionString?: string,
+      /** passed directly to node.TLSSocket, supports all tls.connect options*/ ssl?: unknown,
+      /** custom type parsers*/ types?: unknown,
+      /** number of milliseconds before a statement in query will time out, default is no timeout*/
+      statement_timeout?: float,
+      /** number of milliseconds before a query call will timeout, default is no timeout*/
+      query_timeout?: float,
+      /** number of milliseconds a query is allowed to be en lock state before it's cancelled due to lock timeout*/
+      lock_timeout?: float,
+      /** The name of the application that created this Client instance*/ application_name?: string,
+      /** number of milliseconds to wait for connection, default is no timeout*/
       connectionTimeoutMillis?: float,
+      /** number of milliseconds before terminating any session with an open idle transaction, default is no timeout*/
+      idle_in_transaction_session_timeout?: float,
       /** number of milliseconds a client must sit idle in the pool and not be checked out
  before it is disconnected from the backend and discarded
    default is 10000 (10 seconds) - set to 0 to disable auto-disconnection of idle clients*/
@@ -108,7 +121,13 @@ module Pg = {
     @unboxed
     type pgConfig = Config(config) | ConnectionString(string)
 
-    @module("pg") @new external make: pgConfig => t = "Pool"
+    @module("pg") @new external makeWithConfig: config => t = "Pool"
+
+    let make = config =>
+      switch config {
+      | Config(config) => makeWithConfig(config)
+      | ConnectionString(connectionString) => makeWithConfig({connectionString: connectionString})
+      }
 
     @send
     external query: (t, string, ~values: array<pgValue>=?) => promise<PgResult.t<'result>> = "query"

--- a/packages/cli/src/rescript.test.ts
+++ b/packages/cli/src/rescript.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'child_process';
 import { readFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
@@ -15,8 +16,21 @@ type PgTypedBindings = {
   };
 };
 
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const packageDir = join(currentDir, '..');
+
+const buildPgTypedBindings = () => {
+  execFileSync('npx', ['rescript', 'clean'], {
+    cwd: packageDir,
+    stdio: 'inherit',
+  });
+  execFileSync('npx', ['rescript'], {
+    cwd: packageDir,
+    stdio: 'inherit',
+  });
+};
+
 const loadPgTypedBindings = () => {
-  const currentDir = dirname(fileURLToPath(import.meta.url));
   const source = readFileSync(join(currentDir, 'res/PgTyped.js'), 'utf8');
 
   class Pool {
@@ -42,6 +56,10 @@ const loadPgTypedBindings = () => {
 
   return context.exports as PgTypedBindings;
 };
+
+beforeAll(() => {
+  buildPgTypedBindings();
+});
 
 test('Pool.make wraps connection strings in a pool config object', () => {
   const pgTyped = loadPgTypedBindings();

--- a/packages/cli/src/rescript.test.ts
+++ b/packages/cli/src/rescript.test.ts
@@ -1,3 +1,65 @@
-test('test', () => {
-  expect(true).toBe(true);
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import vm from 'vm';
+
+type PoolInstance = {
+  options: unknown;
+};
+
+type PgTypedBindings = {
+  Pg: {
+    Pool: {
+      make: (config: unknown) => PoolInstance;
+    };
+  };
+};
+
+const loadPgTypedBindings = () => {
+  const currentDir = dirname(fileURLToPath(import.meta.url));
+  const source = readFileSync(join(currentDir, 'res/PgTyped.js'), 'utf8');
+
+  class Pool {
+    public options: unknown;
+
+    public constructor(options: unknown) {
+      this.options = options;
+    }
+  }
+
+  const context = {
+    exports: {},
+    require: (name: string) => {
+      if (name === 'pg') {
+        return { Pool };
+      }
+
+      throw new Error(`Unexpected require: ${name}`);
+    },
+  };
+
+  vm.runInNewContext(source, context, { filename: 'PgTyped.js' });
+
+  return context.exports as PgTypedBindings;
+};
+
+test('Pool.make wraps connection strings in a pool config object', () => {
+  const pgTyped = loadPgTypedBindings();
+  const connectionString = 'postgres://user:password@localhost/database';
+
+  const pool = pgTyped.Pg.Pool.make(connectionString);
+
+  expect(pool.options).toEqual({ connectionString });
+});
+
+test('Pool.make passes config objects through unchanged', () => {
+  const pgTyped = loadPgTypedBindings();
+  const config = {
+    connectionString: 'postgres://user:password@localhost/database',
+    max: 10,
+  };
+
+  const pool = pgTyped.Pg.Pool.make(config);
+
+  expect(pool.options).toBe(config);
 });


### PR DESCRIPTION
Fixes #22.\n\nChanges:\n- Wrap Pg.Pool.make(ConnectionString(...)) as { connectionString } before calling new Pool.\n- Add client connection fields, including connectionString, to Pg.Pool.config.\n- Correct Pg.Client.release to return unit; node-postgres returns undefined for release().\n- Add a focused regression test for generated Pool.make behavior.\n\nVerification:\n- npm run build --workspace packages/cli\n- npm run build --workspace packages/example\n- npm test --workspace packages/cli -- --runTestsByPath src/rescript.test.ts\n- NODE_VERSION=20 CI=true docker compose -f packages/example/docker-compose.yml run test