### PR TITLE
Update 3.0.0 release docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,19 @@
 # main
 
+# 3.0.0
+
+- BREAKING: Require ReScript `>=12.0.0`.
+- BREAKING: Remove the dependency on `@rescript/core`.
+- BREAKING: Remove the dependency on `@rescript/tools`; the CLI now uses the ReScript compiler toolchain from the installed `rescript` package.
+- Fix `Pg.Pool.make(ConnectionString(...))` so it creates a pool with `{connectionString}` instead of passing a raw string to `pg.Pool`.
+- Fix `Pg.Client.release` binding to return `unit`, matching `node-postgres`.
+- Use `chokidar` for build-mode file matching so glob-style `srcDir` patterns are handled consistently with watch mode.
 - Make sure `JSON.t` is properly stringified so JSON arrays can be passed to params expecting `JSON.t` without them being confused for regular Postgres arrays.
 - Auto-escape all ReScript keywords in generated record field names.
 - Add automatic parsing of PostgreSQL check constraints to generate ReScript polyvariant types for enumeration-style constraints. Supports both `column IN (value1, value2, ...)` and `column = ANY (ARRAY[value1, value2, ...])` patterns with string and integer values.
-- Add top-level literal inference for SELECT queries. When a query returns literal values with aliases (e.g., `SELECT 'success' as status, 42 as code`), PgTyped now automatically infers specific polyvariant types like `[#"success"]` and `[#42]` instead of generic `string` and `int` types. This provides better type safety and autocompletion. Also works with UNION queries where literals are consistent across all branches.
+- Add top-level literal inference for SELECT queries. When a query returns literal values with aliases (e.g. `SELECT 'success' as status, 42 as code`), PgTyped now automatically infers specific polyvariant types like `[#"success"]` and `[#42]` instead of generic `string` and `int` types. This provides better type safety and autocompletion. Also works with UNION queries where literals are consistent across all branches.
 - Add support for PostgreSQL JSON population functions (`json_populate_record`, `json_populate_recordset`, `jsonb_populate_record`, `jsonb_populate_recordset`, `json_to_record`, `jsonb_to_recordset`). This supports efficient bulk operations.
-- Remove dependency on `@rescript/core` since it's not really used.
+- Use the `queryConfig` API in `pgtyped-rescript-runtime`.
 
 # 2.6.0
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ PgTyped parses the SQL file, extracting all queries and generating strictly type
 
 ```rescript
 type findBookByIdParams = {
-  bookId: option<int>,
+  bookId?: int,
 }
 
 type findBookByIdResult = {
@@ -81,7 +81,7 @@ let client = Pg.Client.make(Config({
 
 let main = async () => {
   await client->Pg.Client.connect
-  let books = await Books__sql.FindBookById.many(client, {bookId: Some(5)})
+  let books = await Books__sql.FindBookById.many(client, {bookId: 5})
   Js.log2("Book name:", books[0].name)
   await client->Pg.Client.end
 }

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Visit our documentation page at [https://pgtyped.dev/](https://pgtyped.dev/)
 
 ### Getting started
 
-1. `npm install -D pgtyped-rescript rescript`
-2. `npm install pgtyped-rescript-runtime pgtyped-rescript-query`
+1. `npm install pgtyped-rescript pgtyped-rescript-runtime pgtyped-rescript-query`
+2. `npm install -D rescript`
 3. Create a PgTyped `config.json` file.
 4. Run `npx pgtyped-rescript -w -c config.json` to start PgTyped in watch mode.
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ let main = async () => {
   Js.log2("Book name:", books[0].name)
   await client->Pg.Client.end
 }
+
+main()->Promise.done
 ```
 
 ### Resources

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ Visit our documentation page at [https://pgtyped.dev/](https://pgtyped.dev/)
 
 ### Getting started
 
-1. `npm install -D @pgtyped/cli typescript` (typescript is a required peer dependency for pgtyped)
-2. `npm install @pgtyped/runtime` (`@pgtyped/runtime` is the only required runtime dependency of pgtyped)
+1. `npm install -D pgtyped-rescript rescript`
+2. `npm install pgtyped-rescript-runtime pgtyped-rescript-query`
 3. Create a PgTyped `config.json` file.
-4. Run `npx pgtyped -w -c config.json` to start PgTyped in watch mode.
+4. Run `npx pgtyped-rescript -w -c config.json` to start PgTyped in watch mode.
 
 More info on getting started can be found in the [Getting Started](https://pgtyped.dev/docs/getting-started) page.
 You can also refer to the [example app](./packages/example/README.md) for a preconfigured example.
@@ -47,63 +47,44 @@ Lets save some queries in `books.sql`:
 SELECT * FROM books WHERE id = :bookId;
 ```
 
-PgTyped parses the SQL file, extracting all queries and generating strictly typed TS queries in `books.queries.ts`:
+PgTyped parses the SQL file, extracting all queries and generating strictly typed ReScript bindings in `books__sql.res`:
 
-```ts
-/** Types generated for queries found in "books.sql" */
-
-//...
-
-/** 'FindBookById' parameters type */
-export interface IFindBookByIdParams {
-  bookId: number | null;
+```rescript
+type findBookByIdParams = {
+  bookId: option<int>,
 }
 
-/** 'FindBookById' return type */
-export interface IFindBookByIdResult {
-  id: number;
-  rank: number | null;
-  name: string | null;
-  author_id: number | null;
+type findBookByIdResult = {
+  id: int,
+  rank: option<int>,
+  name: option<string>,
+  author_id: option<int>,
 }
 
-/**
- * Query generated from SQL:
- * SELECT * FROM books WHERE id = :bookId
- */
-export const findBookById = new PreparedQuery<
-  IFindBookByIdParams,
-  IFindBookByIdResult
->(...);
+module FindBookById = {
+  let many: (PgTyped.Pg.Client.t, findBookByIdParams) => promise<array<findBookByIdResult>>
+}
 ```
 
-Query `findBookById` is now statically typed, with types inferred from the PostgreSQL schema.  
+Query `FindBookById.many` is now statically typed, with types inferred from the PostgreSQL schema.
 This generated query can be imported and executed as follows:
 
-```ts
-import { Client } from 'pg';
-import { findBookById } from './books.queries';
+```rescript
+open PgTyped
 
-export const client = new Client({
-  host: 'localhost',
-  user: 'test',
-  password: 'example',
-  database: 'test',
-});
+let client = Pg.Client.make(Config({
+  host: "localhost",
+  user: "test",
+  password: "example",
+  database: "test",
+}))
 
-async function main() {
-  await client.connect();
-  const books = await findBookById.run(
-    {
-      bookId: 5,
-    },
-    client,
-  );
-  console.log(`Book name: ${books[0].name}`);
-  await client.end();
+let main = async () => {
+  await client->Pg.Client.connect
+  let books = await Books__sql.FindBookById.many(client, {bookId: Some(5)})
+  Js.log2("Book name:", books[0].name)
+  await client->Pg.Client.end
 }
-
-main();
 ```
 
 ### Resources
@@ -111,8 +92,6 @@ main();
 1. [Configuring pgTyped](https://pgtyped.dev/docs/cli)
 2. [Writing queries in SQL files](https://pgtyped.dev/docs/sql-file-intro)
 3. [Advanced queries and parameter expansions in SQL files](https://pgtyped.dev/docs/sql-file)
-4. [Writing queries in TS files](https://pgtyped.dev/docs/ts-file-intro)
-5. [Advanced queries and parameter expansions in TS files](https://pgtyped.dev/docs/ts-file)
 
 ### Project state:
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -45,7 +45,7 @@ Config file format (`config.json`):
     {
       "mode": "res", // ReScript mode
       "include": "**/*.res", // ReScript files pattern to scan for embedded SQL
-      "emitTemplate": "{{dir}}/{{name}}__sql.res" // File name template to save generated files
+      "emitTemplate": "{{dir}}/{{name}}__res.res" // File name template to save generated files
     }
   ],
   "srcDir": "./src/", // Directory to scan or watch for query files

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -40,12 +40,12 @@ Config file format (`config.json`):
     {
       "mode": "sql", // SQL mode
       "include": "**/*.sql", // SQL files pattern to scan for queries
-      "emitTemplate": "{{dir}}/{{name}}__sql.res" // File name template to save generated files
+      "emitTemplate": "{{dir}}/{{name}}__queries.res" // File name template to save generated files
     },
     {
       "mode": "res", // ReScript mode
       "include": "**/*.res", // ReScript files pattern to scan for embedded SQL
-      "emitTemplate": "{{dir}}/{{name}}__res.res" // File name template to save generated files
+      "emitTemplate": "{{dir}}/{{name}}__sql.res" // File name template to save generated files
     }
   ],
   "srcDir": "./src/", // Directory to scan or watch for query files

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,7 +1,7 @@
-## @pgtyped/cli
+## pgtyped-rescript
 
-This package provides the `pgtyped` CLI.  
-The `pgtyped` CLI can work in build and watch mode.
+This package provides the `pgtyped-rescript` CLI.
+The `pgtyped-rescript` CLI can work in build and watch mode.
 
 ### Flags:
 
@@ -13,7 +13,7 @@ The CLI supports two flags:
 Running the CLI:
 
 ```
-npx pgtyped -w -c config.json
+npx pgtyped-rescript -w -c config.json
 ```
 
 ### Env variables:
@@ -35,17 +35,17 @@ Config file format (`config.json`):
 ```js
 {
   // You can specify as many transforms as you want
-  // Only TS and SQL files (modes) are supported at the moment
+  // ReScript and SQL files are supported.
   "transforms": [
     {
       "mode": "sql", // SQL mode
       "include": "**/*.sql", // SQL files pattern to scan for queries
-      "emitTemplate": "{{dir}}/{{name}}.queries.ts" // File name template to save generated files
+      "emitTemplate": "{{dir}}/{{name}}__sql.res" // File name template to save generated files
     },
     {
-      "mode": "ts", // TS mode
-      "include": "**/action.ts", // TS file pattern to scan for queries
-      "emitTemplate": "{{dir}}/{{name}}.types.ts" // File name template to save generated files
+      "mode": "res", // ReScript mode
+      "include": "**/*.res", // ReScript files pattern to scan for embedded SQL
+      "emitTemplate": "{{dir}}/{{name}}__sql.res" // File name template to save generated files
     }
   ],
   "srcDir": "./src/", // Directory to scan or watch for query files
@@ -62,9 +62,9 @@ Config file format (`config.json`):
 
 ### Generated files
 
-By default, PgTyped saves generated files in the same folder as the source files it parses.  
-This behavior can be customized using the `emitTemplate` config parameter.  
-In that template, four parameters are available for interpolation: `root`, `dir`, `base`, `name` and `ext`.  
+By default, PgTyped saves generated files in the same folder as the source files it parses.
+This behavior can be customized using the `emitTemplate` config parameter.
+In that template, four parameters are available for interpolation: `root`, `dir`, `base`, `name` and `ext`.
 For example, when parsing source/query file `/home/user/dir/file.sql`, these parameters are assigned the following values:
 
 ```
@@ -79,5 +79,5 @@ For example, when parsing source/query file `/home/user/dir/file.sql`, these par
 
 ---
 
-This package is part of the PgTyped project.  
-Refer to root [README](https://github.com/adelsz/pgtyped) for details.
+This package is part of the ReScript fork of PgTyped.
+Refer to the root [README](../../README.md) for details.

--- a/packages/query/README.md
+++ b/packages/query/README.md
@@ -1,6 +1,6 @@
-## @pgtyped/query
+## pgtyped-rescript-query
 
 This package provides protocol utilities for PgTyped queries.
 
-This package is part of the pgtyped project.  
-Refer to [README](https://github.com/adelsz/pgtyped) for details.
+This package is part of the ReScript fork of PgTyped.
+Refer to the root [README](../../README.md) for details.

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -1,10 +1,10 @@
-## @pgtyped/runtime
+## pgtyped-rescript-runtime
 
-This package provides the `sql` tagged template.  
+This package provides the `sql` tagged template.
 The `sql` tagged template requires a generic parameter: `<TQueryType>`.
 For each query PgTyped generates an interface that can be used in this parameter to type your query.
 
-To run a query defined with the `sql` tagged template, call the `sql.run` method.  
+To run a query defined with the `sql` tagged template, call the `sql.run` method.
 The `sql.run` method automatically enforces correct input `TParams` and output `TResult` types.
 
 ```js
@@ -24,5 +24,5 @@ interface IDatabaseConnection {
 
 This is usually the `client` object created with [node-postgres](https://github.com/brianc/node-postgres), but can be any other connection of your choice.
 
-This package is part of the pgtyped project.  
-Refer to [README](https://github.com/adelsz/pgtyped) for details.
+This package is part of the ReScript fork of PgTyped.
+Refer to the root [README](../../README.md) for details.


### PR DESCRIPTION
Prepares release documentation for 3.0.0.\n\nChanges:\n- Add a 3.0.0 changelog section covering the unreleased ReScript package changes.\n- Update ReScript package README names and links.\n- Update CLI README examples to use pgtyped-rescript, ReScript mode, and .res output.\n- Update root README install and example snippets for the ReScript fork.\n\nVerification:\n- git diff --check