### PR TITLE
Bump ReScript packages to 3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12448,7 +12448,7 @@
     },
     "packages/cli": {
       "name": "pgtyped-rescript",
-      "version": "2.6.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@pgtyped/parser": "^2.1.0",
@@ -12463,7 +12463,7 @@
         "io-ts-reporters": "^2.0.1",
         "nunjucks": "3.2.4",
         "pascal-case": "^3.1.1",
-        "pgtyped-rescript-query": "^2.4.0",
+        "pgtyped-rescript-query": "^3.0.0",
         "piscina": "^4.0.0",
         "tinypool": "^0.7.0",
         "ts-parse-database-url": "^1.0.3",
@@ -12531,8 +12531,8 @@
       "dependencies": {
         "expect": "29.6.2",
         "pg": "8.11.2",
-        "pgtyped-rescript": "^2.4.0",
-        "pgtyped-rescript-query": "^2.3.0",
+        "pgtyped-rescript": "^3.0.0",
+        "pgtyped-rescript-query": "^3.0.0",
         "rescript": "12.2.0",
         "rescript-embed-lang": "^0.5.5",
         "typescript": "4.9.4"
@@ -12614,14 +12614,14 @@
     },
     "packages/query": {
       "name": "pgtyped-rescript-query",
-      "version": "2.4.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@pgtyped/wire": "^2.2.0",
         "chalk": "^4.1.0",
         "debug": "^4.1.1",
         "pgsql-ast-parser": "^12.0.1",
-        "pgtyped-rescript-runtime": "^2.2.0"
+        "pgtyped-rescript-runtime": "^3.0.0"
       },
       "devDependencies": {
         "@types/chalk": "^2.2.0",
@@ -12633,7 +12633,7 @@
     },
     "packages/runtime": {
       "name": "pgtyped-rescript-runtime",
-      "version": "2.2.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@pgtyped/parser": "^2.1.0",
@@ -14230,8 +14230,8 @@
         "@types/pg": "8.10.2",
         "expect": "29.6.2",
         "pg": "8.11.2",
-        "pgtyped-rescript": "^2.4.0",
-        "pgtyped-rescript-query": "^2.3.0",
+        "pgtyped-rescript": "^3.0.0",
+        "pgtyped-rescript-query": "^3.0.0",
         "rescript": "12.2.0",
         "rescript-embed-lang": "^0.5.5",
         "ts-node": "10.9.1",
@@ -19972,7 +19972,7 @@
         "io-ts-reporters": "^2.0.1",
         "nunjucks": "3.2.4",
         "pascal-case": "^3.1.1",
-        "pgtyped-rescript-query": "^2.4.0",
+        "pgtyped-rescript-query": "^3.0.0",
         "piscina": "^4.0.0",
         "rescript": "12.2.0",
         "tinypool": "^0.7.0",
@@ -20005,7 +20005,7 @@
         "chalk": "^4.1.0",
         "debug": "^4.1.1",
         "pgsql-ast-parser": "^12.0.1",
-        "pgtyped-rescript-runtime": "^2.2.0"
+        "pgtyped-rescript-runtime": "^3.0.0"
       }
     },
     "pgtyped-rescript-runtime": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pgtyped-rescript",
-  "version": "2.6.0",
+  "version": "3.0.0",
   "type": "module",
   "main": "lib/index.js",
   "exports": {
@@ -48,7 +48,7 @@
     "io-ts-reporters": "^2.0.1",
     "nunjucks": "3.2.4",
     "pascal-case": "^3.1.1",
-    "pgtyped-rescript-query": "^2.4.0",
+    "pgtyped-rescript-query": "^3.0.0",
     "piscina": "^4.0.0",
     "tinypool": "^0.7.0",
     "ts-parse-database-url": "^1.0.3",

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -24,8 +24,8 @@
   "dependencies": {
     "expect": "29.6.2",
     "pg": "8.11.2",
-    "pgtyped-rescript": "^2.4.0",
-    "pgtyped-rescript-query": "^2.3.0",
+    "pgtyped-rescript": "^3.0.0",
+    "pgtyped-rescript-query": "^3.0.0",
     "rescript": "12.2.0",
     "rescript-embed-lang": "^0.5.5",
     "typescript": "4.9.4"

--- a/packages/example/src/PgTyped.gen.tsx
+++ b/packages/example/src/PgTyped.gen.tsx
@@ -1,4 +1,4 @@
-import type {Client} from 'pg';
+import type { Client } from 'pg';
 
 export type Pg_Client_t = Client;
 export type dateOrString = string;

--- a/packages/example/src/books/PgTyped.gen.tsx
+++ b/packages/example/src/books/PgTyped.gen.tsx
@@ -1,1 +1,1 @@
-export type {Pg_Client_t, dateOrString} from '../PgTyped.gen';
+export type { Pg_Client_t, dateOrString } from '../PgTyped.gen';

--- a/packages/example/src/comments/PgTyped.gen.tsx
+++ b/packages/example/src/comments/PgTyped.gen.tsx
@@ -1,1 +1,1 @@
-export type {Pg_Client_t, dateOrString} from '../PgTyped.gen';
+export type { Pg_Client_t, dateOrString } from '../PgTyped.gen';

--- a/packages/example/src/notifications/PgTyped.gen.tsx
+++ b/packages/example/src/notifications/PgTyped.gen.tsx
@@ -1,1 +1,1 @@
-export type {Pg_Client_t, dateOrString} from '../PgTyped.gen';
+export type { Pg_Client_t, dateOrString } from '../PgTyped.gen';

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pgtyped-rescript-query",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "type": "module",
   "exports": {
     ".": {
@@ -32,7 +32,7 @@
     "watch": "tsc --watch --preserveWatchOutput"
   },
   "dependencies": {
-    "pgtyped-rescript-runtime": "^2.2.0",
+    "pgtyped-rescript-runtime": "^3.0.0",
     "@pgtyped/wire": "^2.2.0",
     "chalk": "^4.1.0",
     "debug": "^4.1.1",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pgtyped-rescript-runtime",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary
- Bump the publishable ReScript packages to 3.0.0
- Update internal ReScript package dependency ranges to ^3.0.0
- Regenerate example bindings after pointing the example at the 3.0.0 workspace packages

## Verification
- npm ci
- npm run build
- npm run lint
- npx lerna run test --ignore @pgtyped/example --stream
- npm test
- npm publish --dry-run for pgtyped-rescript-runtime, pgtyped-rescript-query, and pgtyped-rescript