### PR TITLE
Fix package repository metadata for provenance

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adelsz/pgtyped.git"
+    "url": "git+https://github.com/zth/pgtyped-rescript.git"
   },
   "files": [
     "rescript.json",
@@ -22,7 +22,7 @@
   "engines": {
     "node": ">=14.16"
   },
-  "homepage": "https://github.com/adelsz/pgtyped",
+  "homepage": "https://github.com/zth/pgtyped-rescript",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -19,9 +19,9 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adelsz/pgtyped.git"
+    "url": "git+https://github.com/zth/pgtyped-rescript.git"
   },
-  "homepage": "https://github.com/adelsz/pgtyped",
+  "homepage": "https://github.com/zth/pgtyped-rescript",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -19,9 +19,9 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adelsz/pgtyped.git"
+    "url": "git+https://github.com/zth/pgtyped-rescript.git"
   },
-  "homepage": "https://github.com/adelsz/pgtyped",
+  "homepage": "https://github.com/zth/pgtyped-rescript",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -20,9 +20,9 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adelsz/pgtyped.git"
+    "url": "git+https://github.com/zth/pgtyped-rescript.git"
   },
-  "homepage": "https://github.com/adelsz/pgtyped",
+  "homepage": "https://github.com/zth/pgtyped-rescript",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/wire/package.json
+++ b/packages/wire/package.json
@@ -13,9 +13,9 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adelsz/pgtyped.git"
+    "url": "git+https://github.com/zth/pgtyped-rescript.git"
   },
-  "homepage": "https://github.com/adelsz/pgtyped",
+  "homepage": "https://github.com/zth/pgtyped-rescript",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary
- Point package repository/homepage metadata at zth/pgtyped-rescript
- Use npm's canonical git+https repository URL so provenance validation matches the GitHub Actions source repository

## Verification
- npm publish --dry-run for pgtyped-rescript-runtime, pgtyped-rescript-query, and pgtyped-rescript